### PR TITLE
Update Add student command format

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -41,10 +41,6 @@ public class Messages {
                 .append(person.getEmail())
                 .append("; Student ID: ")
                 .append(person.getStudentId())
-                .append("; Module: ")
-                .append(person.getModule())
-                .append("; Tutorial: ")
-                .append(person.getTutorialClass())
                 .append("; Tags: ");
         person.getTags().forEach(builder::append);
         return builder.toString();

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -2,11 +2,9 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULECODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIALCLASS;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
@@ -19,22 +17,18 @@ import seedu.address.model.person.Person;
  */
 public class AddCommand extends Command {
 
-    public static final String COMMAND_WORD = "add";
+    public static final String COMMAND_WORD = "/add_student";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to TAHelper. "
             + "Parameters: "
             + PREFIX_NAME + "NAME "
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_STUDENTID + "STUDENT ID "
-            + PREFIX_MODULECODE + "MODULE CODE "
-            + PREFIX_TUTORIALCLASS + "TUTORIAL "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "Zack "
             + PREFIX_STUDENTID + "A12345678Z "
             + PREFIX_EMAIL + "Zack@example.com "
-            + PREFIX_MODULECODE + "CS1101S "
-            + PREFIX_TUTORIALCLASS + "T01 "
             + PREFIX_TAG + "Student ";
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -2,7 +2,6 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULECODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -21,8 +20,6 @@ import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.module.ModuleCode;
-import seedu.address.model.module.TutorialClass;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
@@ -43,7 +40,6 @@ public class EditCommand extends Command {
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_STUDENTID + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
-            + "[" + PREFIX_MODULECODE + "ADDRESS] "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_STUDENTID + "91234567 "
@@ -99,13 +95,9 @@ public class EditCommand extends Command {
         Name updatedName = editPersonDescriptor.getName().orElse(personToEdit.getName());
         Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
         StudentId updatedStudentId = editPersonDescriptor.getStudentId().orElse(personToEdit.getStudentId());
-        ModuleCode updatedModule = editPersonDescriptor.getModuleCode().orElse(personToEdit.getModule());
-        TutorialClass updatedTutorialClass = editPersonDescriptor.getTutorialClass()
-                .orElse(personToEdit.getTutorialClass());
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
 
-        return new Person(updatedName, updatedEmail, updatedStudentId,
-                updatedModule, updatedTutorialClass, updatedTags);
+        return new Person(updatedName, updatedEmail, updatedStudentId, updatedTags);
     }
 
     @Override
@@ -139,8 +131,6 @@ public class EditCommand extends Command {
     public static class EditPersonDescriptor {
         private Name name;
         private Email email;
-        private ModuleCode moduleCode;
-        private TutorialClass tutorial;
         private StudentId studentId;
         private Set<Tag> tags;
 
@@ -154,8 +144,6 @@ public class EditCommand extends Command {
             setName(toCopy.name);
             setEmail(toCopy.email);
             setStudentId(toCopy.studentId);
-            setModuleCode(toCopy.moduleCode);
-            setTutorialClass(toCopy.tutorial);
             setTags(toCopy.tags);
         }
 
@@ -163,7 +151,7 @@ public class EditCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, email, studentId, moduleCode, tutorial, tags);
+            return CollectionUtil.isAnyNonNull(name, email, studentId, tags);
         }
 
         public void setName(Name name) {
@@ -187,21 +175,6 @@ public class EditCommand extends Command {
         }
         public Optional<StudentId> getStudentId() {
             return Optional.ofNullable(studentId);
-        }
-
-        public void setModuleCode(ModuleCode moduleCode) {
-            this.moduleCode = moduleCode;
-        }
-
-        public Optional<ModuleCode> getModuleCode() {
-            return Optional.ofNullable(moduleCode);
-        }
-
-        public void setTutorialClass(TutorialClass tutorial) {
-            this.tutorial = tutorial;
-        }
-        public Optional<TutorialClass> getTutorialClass() {
-            return Optional.ofNullable(tutorial);
         }
 
         /**
@@ -236,8 +209,6 @@ public class EditCommand extends Command {
             return Objects.equals(name, otherEditPersonDescriptor.name)
                     && Objects.equals(email, otherEditPersonDescriptor.email)
                     && Objects.equals(studentId, otherEditPersonDescriptor.studentId)
-                    && Objects.equals(moduleCode, otherEditPersonDescriptor.moduleCode)
-                    && Objects.equals(tutorial, otherEditPersonDescriptor.tutorial)
                     && Objects.equals(tags, otherEditPersonDescriptor.tags);
         }
 
@@ -247,8 +218,6 @@ public class EditCommand extends Command {
                     .add("name", name)
                     .add("email", email)
                     .add("studentID", studentId)
-                    .add("module", moduleCode)
-                    .add("tutorial", tutorial)
                     .add("tags", tags)
                     .toString();
         }

--- a/src/main/java/seedu/address/logic/commands/deletestudentcommands/DeleteStudentByEmailCommand.java
+++ b/src/main/java/seedu/address/logic/commands/deletestudentcommands/DeleteStudentByEmailCommand.java
@@ -35,7 +35,6 @@ public class DeleteStudentByEmailCommand extends DeleteStudentCommand {
         personToDelete = model.searchPersonByPredicate(person -> person.getEmail().equals(email));
         if (personToDelete == null) {
             throw new CommandException(String.format(MESSAGE_PERSON_EMAIL_NOT_FOUND, email));
-
         }
         model.deletePerson(personToDelete);
 

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -2,19 +2,15 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULECODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIALCLASS;
 
 import java.util.Set;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.module.ModuleCode;
-import seedu.address.model.module.TutorialClass;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
@@ -33,25 +29,20 @@ public class AddCommandParser implements Parser<AddCommand> {
      */
     public AddCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-            ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_EMAIL, PREFIX_STUDENTID,
-                PREFIX_MODULECODE, PREFIX_TUTORIALCLASS, PREFIX_TAG);
+            ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_EMAIL, PREFIX_STUDENTID, PREFIX_TAG);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_EMAIL, PREFIX_STUDENTID,
-            PREFIX_MODULECODE, PREFIX_TUTORIALCLASS)
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_EMAIL, PREFIX_STUDENTID)
             || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_STUDENTID, PREFIX_EMAIL,
-            PREFIX_MODULECODE, PREFIX_TUTORIALCLASS);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_STUDENTID, PREFIX_EMAIL);
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         StudentId studentId = ParserUtil.parseStudentId(argMultimap.getValue(PREFIX_STUDENTID).get());
-        ModuleCode moduleCode = ParserUtil.parseModuleCode(argMultimap.getValue(PREFIX_MODULECODE).get());
-        TutorialClass tutorial = ParserUtil.parseTutorialClass(argMultimap.getValue(PREFIX_TUTORIALCLASS).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
-        Person person = new Person(name, email, studentId, moduleCode, tutorial, tagList);
+        Person person = new Person(name, email, studentId, tagList);
 
         return new AddCommand(person);
     }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -3,11 +3,9 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULECODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIALCLASS;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -33,8 +31,7 @@ public class EditCommandParser implements Parser<EditCommand> {
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_EMAIL, PREFIX_STUDENTID,
-                        PREFIX_MODULECODE, PREFIX_TUTORIALCLASS, PREFIX_TAG);
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_EMAIL, PREFIX_STUDENTID, PREFIX_TAG);
 
         Index index;
 
@@ -44,8 +41,7 @@ public class EditCommandParser implements Parser<EditCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_EMAIL, PREFIX_STUDENTID,
-                PREFIX_MODULECODE, PREFIX_TUTORIALCLASS);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_EMAIL, PREFIX_STUDENTID);
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
 
@@ -57,14 +53,6 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
         if (argMultimap.getValue(PREFIX_STUDENTID).isPresent()) {
             editPersonDescriptor.setStudentId(ParserUtil.parseStudentId(argMultimap.getValue(PREFIX_STUDENTID).get()));
-        }
-        if (argMultimap.getValue(PREFIX_MODULECODE).isPresent()) {
-            editPersonDescriptor.setModuleCode(
-                    ParserUtil.parseModuleCode(argMultimap.getValue(PREFIX_MODULECODE).get()));
-        }
-        if (argMultimap.getValue(PREFIX_TUTORIALCLASS).isPresent()) {
-            editPersonDescriptor.setTutorialClass(
-                    ParserUtil.parseTutorialClass(argMultimap.getValue(PREFIX_TUTORIALCLASS).get()));
         }
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
 

--- a/src/main/java/seedu/address/logic/parser/SearchStudentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SearchStudentCommandParser.java
@@ -3,18 +3,14 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULECODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIALCLASS;
 
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.SearchStudentCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.module.ModuleContainsKeywordPredicate;
-import seedu.address.model.module.TutorialContainsKeywordPredicate;
 import seedu.address.model.person.EmailContainsKeywordPredicate;
 import seedu.address.model.person.NameContainsKeywordPredicate;
 import seedu.address.model.person.Person;
@@ -34,26 +30,16 @@ public class SearchStudentCommandParser implements Parser<SearchStudentCommand> 
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(
-                        args, PREFIX_NAME, PREFIX_STUDENTID, PREFIX_EMAIL, PREFIX_MODULECODE, PREFIX_TUTORIALCLASS);
+                        args, PREFIX_NAME, PREFIX_STUDENTID, PREFIX_EMAIL);
 
-        if (!hasOnlyOnePrefix(argMultimap, PREFIX_NAME, PREFIX_STUDENTID, PREFIX_EMAIL,
-                PREFIX_MODULECODE, PREFIX_TUTORIALCLASS)) {
+        if (!hasOnlyOnePrefix(argMultimap, PREFIX_NAME, PREFIX_STUDENTID, PREFIX_EMAIL)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SearchStudentCommand.MESSAGE_USAGE));
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_EMAIL, PREFIX_STUDENTID,
-                PREFIX_MODULECODE, PREFIX_TUTORIALCLASS);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_EMAIL, PREFIX_STUDENTID);
 
         Predicate<Person> predicate = null;
 
-        if (argMultimap.getValue(PREFIX_TUTORIALCLASS).isPresent()) {
-            String keyword = argMultimap.getValue(PREFIX_TUTORIALCLASS).get();
-            predicate = new TutorialContainsKeywordPredicate(keyword);
-        }
-        if (argMultimap.getValue(PREFIX_MODULECODE).isPresent()) {
-            String keyword = argMultimap.getValue(PREFIX_MODULECODE).get();
-            predicate = new ModuleContainsKeywordPredicate(keyword);
-        }
         if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
             String keyword = argMultimap.getValue(PREFIX_EMAIL).get();
             predicate = new EmailContainsKeywordPredicate(keyword);
@@ -69,7 +55,6 @@ public class SearchStudentCommandParser implements Parser<SearchStudentCommand> 
         if (predicate == null) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SearchStudentCommand.MESSAGE_USAGE));
         }
-
 
         return new SearchStudentCommand(predicate);
     }

--- a/src/main/java/seedu/address/model/module/ModuleCode.java
+++ b/src/main/java/seedu/address/model/module/ModuleCode.java
@@ -26,12 +26,12 @@ public class ModuleCode {
     /**
      * A constructor for Module. Used to initialise a new module with no tutorial classes
      *
-     * @param name of the module to be created
+     * @param moduleCode of the module to be created
      */
-    public ModuleCode(String name) {
-        requireAllNonNull(name);
-        checkArgument(isValidModuleCode(name), MESSAGE_CONSTRAINTS);
-        this.value = name;
+    public ModuleCode(String moduleCode) {
+        requireAllNonNull(moduleCode);
+        checkArgument(isValidModuleCode(moduleCode), MESSAGE_CONSTRAINTS);
+        this.value = moduleCode;
         this.tutorialClasses = new ArrayList<TutorialClass>();
     }
 
@@ -39,28 +39,28 @@ public class ModuleCode {
      * A constructor for Module. Used to initialise a new module with the tutorial class specified.
      * This is the constructor used when /add_class is used.
      *
-     * @param name of the module to be created
+     * @param moduleCode of the module to be created
      * @param tutorialClass to be added within the module
      */
-    public ModuleCode(String name, String tutorialClass) {
-        requireAllNonNull(name);
-        checkArgument(isValidModuleCode(name), MESSAGE_CONSTRAINTS);
-        this.value = name;
+    public ModuleCode(String moduleCode, String tutorialClass) {
+        requireAllNonNull(moduleCode);
+        checkArgument(isValidModuleCode(moduleCode), MESSAGE_CONSTRAINTS);
+        this.value = moduleCode;
         this.tutorialClasses = new ArrayList<TutorialClass>();
         tutorialClasses.add(new TutorialClass(tutorialClass));
     }
 
     /**
      * A constructor for Module. Used to initialise a new module with the list of tutorial classes specified.
-     * Used to get the representation of the module from the list of classes and the name specified.
+     * Used to get the representation of the module from the list of classes and the moduleCode specified.
      *
-     * @param name of the module to be created
+     * @param moduleCode of the module to be created
      * @param tutorialClasses of the module to be created
      */
-    public ModuleCode(String name, ArrayList<TutorialClass> tutorialClasses) {
-        requireAllNonNull(name);
-        checkArgument(isValidModuleCode(name), MESSAGE_CONSTRAINTS);
-        this.value = name;
+    public ModuleCode(String moduleCode, ArrayList<TutorialClass> tutorialClasses) {
+        requireAllNonNull(moduleCode);
+        checkArgument(isValidModuleCode(moduleCode), MESSAGE_CONSTRAINTS);
+        this.value = moduleCode;
         this.tutorialClasses = tutorialClasses;
     }
 
@@ -78,6 +78,14 @@ public class ModuleCode {
      */
     public ArrayList<TutorialClass> getTutorialClasses() {
         return tutorialClasses;
+    }
+
+    /**
+     * Get the instance's object.
+     * @return A ModuleCode instance object.
+     */
+    public ModuleCode getModule() {
+        return this;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/module/ModuleContainsKeywordPredicate.java
+++ b/src/main/java/seedu/address/model/module/ModuleContainsKeywordPredicate.java
@@ -4,12 +4,11 @@ import java.util.function.Predicate;
 
 import seedu.address.commons.util.StringUtil;
 import seedu.address.commons.util.ToStringBuilder;
-import seedu.address.model.person.Person;
 
 /**
  * Tests that a {@code Person}'s {@code ModuleCode} matches the keyword given.
  */
-public class ModuleContainsKeywordPredicate implements Predicate<Person> {
+public class ModuleContainsKeywordPredicate implements Predicate<ModuleCode> {
 
     private final String keyword;
 
@@ -18,8 +17,8 @@ public class ModuleContainsKeywordPredicate implements Predicate<Person> {
     }
 
     @Override
-    public boolean test(Person person) {
-        return StringUtil.containsPartialWordIgnoreCase(person.getModule().value, keyword);
+    public boolean test(ModuleCode moduleCode) {
+        return StringUtil.containsPartialWordIgnoreCase(moduleCode.getModule().value, keyword);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/module/TutorialClass.java
+++ b/src/main/java/seedu/address/model/module/TutorialClass.java
@@ -28,25 +28,25 @@ public class TutorialClass {
     /**
      * A constructor for TutorialClass. Creates an empty tutorial class with no students.
      *
-     * @param name of tutorial to be added
+     * @param tutorialClass of tutorial to be added
      */
-    public TutorialClass(String name) {
-        requireAllNonNull(name);
-        checkArgument(isValidTutorialClass(name), MESSAGE_CONSTRAINTS);
-        this.value = name;
+    public TutorialClass(String tutorialClass) {
+        requireAllNonNull(tutorialClass);
+        checkArgument(isValidTutorialClass(tutorialClass), MESSAGE_CONSTRAINTS);
+        this.value = tutorialClass;
         this.students = new ArrayList<>();
     }
 
     /**
      * A constructor for TutorialClass. Creates a tutorial with the list of students specified.
      *
-     * @param name of tutorial to be added
+     * @param tutorialClass of tutorial to be added
      * @param students to be in the added tutorial
      */
-    public TutorialClass(String name, ArrayList<Person> students) {
-        requireAllNonNull(name);
-        checkArgument(isValidTutorialClass(name), MESSAGE_CONSTRAINTS);
-        this.value = name;
+    public TutorialClass(String tutorialClass, ArrayList<Person> students) {
+        requireAllNonNull(tutorialClass);
+        checkArgument(isValidTutorialClass(tutorialClass), MESSAGE_CONSTRAINTS);
+        this.value = tutorialClass;
         this.students = students;
     }
 
@@ -55,6 +55,12 @@ public class TutorialClass {
      */
     public static boolean isValidTutorialClass(String test) {
         return test.matches(VALIDATION_REGEX);
+    }
+    public TutorialClass getTutorialClass() {
+        return this;
+    }
+    public ArrayList<Person> getStudents() {
+        return this.students;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/module/TutorialContainsKeywordPredicate.java
+++ b/src/main/java/seedu/address/model/module/TutorialContainsKeywordPredicate.java
@@ -4,12 +4,11 @@ import java.util.function.Predicate;
 
 import seedu.address.commons.util.StringUtil;
 import seedu.address.commons.util.ToStringBuilder;
-import seedu.address.model.person.Person;
 
 /**
- * Tests that a {@code Person}'s {@code TutorialClass} matches the keyword given.
+ * Tests that a {@code TutorialClass}'s {@code TutorialClass} matches the keyword given.
  */
-public class TutorialContainsKeywordPredicate implements Predicate<Person> {
+public class TutorialContainsKeywordPredicate implements Predicate<TutorialClass> {
 
     private final String keyword;
 
@@ -18,8 +17,8 @@ public class TutorialContainsKeywordPredicate implements Predicate<Person> {
     }
 
     @Override
-    public boolean test(Person person) {
-        return StringUtil.containsPartialWordIgnoreCase(person.getTutorialClass().value, keyword);
+    public boolean test(TutorialClass tutorialClass) {
+        return StringUtil.containsPartialWordIgnoreCase(tutorialClass.getTutorialClass().value, keyword);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -8,8 +8,6 @@ import java.util.Objects;
 import java.util.Set;
 
 import seedu.address.commons.util.ToStringBuilder;
-import seedu.address.model.module.ModuleCode;
-import seedu.address.model.module.TutorialClass;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -22,22 +20,16 @@ public class Person {
     private final Name name;
     private final Email email;
     private final StudentId stuId;
-
-    // Data fields
-    private final ModuleCode module;
-    private final TutorialClass tutorial;
     private final Set<Tag> tags = new HashSet<>();
 
     /**
      * Every field must be present and not null.
      */
-    public Person(Name name, Email email, StudentId stuId, ModuleCode module, TutorialClass tutorial, Set<Tag> tags) {
-        requireAllNonNull(name, email, stuId, module, tutorial, tags);
+    public Person(Name name, Email email, StudentId stuId, Set<Tag> tags) {
+        requireAllNonNull(name, email, stuId, tags);
         this.name = name;
         this.email = email;
         this.stuId = stuId;
-        this.module = module;
-        this.tutorial = tutorial;
         this.tags.addAll(tags);
     }
 
@@ -49,12 +41,6 @@ public class Person {
     }
     public StudentId getStudentId() {
         return stuId;
-    }
-    public ModuleCode getModule() {
-        return module;
-    }
-    public TutorialClass getTutorialClass() {
-        return tutorial;
     }
 
     /**
@@ -97,15 +83,13 @@ public class Person {
         return name.equals(otherPerson.name)
                 && email.equals(otherPerson.email)
                 && stuId.equals(otherPerson.stuId)
-                && module.equals(otherPerson.module)
-                && tutorial.equals(otherPerson.tutorial)
                 && tags.equals(otherPerson.tags);
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, email, stuId, module, tutorial, tags);
+        return Objects.hash(name, email, stuId, tags);
     }
 
     @Override
@@ -114,8 +98,6 @@ public class Person {
                 .add("name", name)
                 .add("email", email)
                 .add("stuId", stuId)
-                .add("module", module)
-                .add("tutorial", tutorial)
                 .add("tags", tags)
                 .toString();
     }

--- a/src/main/java/seedu/address/model/person/StudentId.java
+++ b/src/main/java/seedu/address/model/person/StudentId.java
@@ -16,7 +16,7 @@ public class StudentId {
     /**
      * This regex validates the NUS student id of a student in the form "A12345678Z"
      */
-    public static final String VALIDATION_REGEX = "^[A]\\d{7}[A-Z]$";
+    public static final String VALIDATION_REGEX = "^A\\d{7}[A-Z]$";
 
     public final String value;
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -10,8 +10,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
-import seedu.address.model.module.ModuleCode;
-import seedu.address.model.module.TutorialClass;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
@@ -28,8 +26,6 @@ class JsonAdaptedPerson {
     private final String name;
     private final String email;
     private final String studentId;
-    private final String moduleCode;
-    private final String tutorial;
     private final List<JsonAdaptedTag> tags = new ArrayList<>();
 
     /**
@@ -37,14 +33,11 @@ class JsonAdaptedPerson {
      */
     @JsonCreator
     public JsonAdaptedPerson(@JsonProperty("name") String name, @JsonProperty("email") String email,
-                             @JsonProperty("studentId") String studentId, @JsonProperty("moduleCode") String moduleCode,
-                             @JsonProperty("tutorial") String tutorial,
+                             @JsonProperty("studentId") String studentId,
                              @JsonProperty("tags") List<JsonAdaptedTag> tags) {
         this.name = name;
         this.email = email;
         this.studentId = studentId;
-        this.moduleCode = moduleCode;
-        this.tutorial = tutorial;
         if (tags != null) {
             this.tags.addAll(tags);
         }
@@ -57,8 +50,6 @@ class JsonAdaptedPerson {
         name = source.getName().fullName;
         email = source.getEmail().value;
         studentId = source.getStudentId().value;
-        moduleCode = source.getModule().value;
-        tutorial = source.getTutorialClass().value;
         tags.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
@@ -101,26 +92,8 @@ class JsonAdaptedPerson {
         }
         final StudentId modelStudentId = new StudentId(studentId);
 
-        if (moduleCode == null) {
-            throw new IllegalValueException(
-                    String.format(MISSING_FIELD_MESSAGE_FORMAT, ModuleCode.class.getSimpleName()));
-        }
-        if (!ModuleCode.isValidModuleCode(moduleCode)) {
-            throw new IllegalValueException(ModuleCode.MESSAGE_CONSTRAINTS);
-        }
-        final ModuleCode modelModuleCode = new ModuleCode(moduleCode);
-
-        if (tutorial == null) {
-            throw new IllegalValueException(
-                    String.format(MISSING_FIELD_MESSAGE_FORMAT, TutorialClass.class.getSimpleName()));
-        }
-        if (!TutorialClass.isValidTutorialClass(tutorial)) {
-            throw new IllegalValueException(TutorialClass.MESSAGE_CONSTRAINTS);
-        }
-        final TutorialClass modelTutorialClass = new TutorialClass(tutorial);
-
         final Set<Tag> modelTags = new HashSet<>(personTags);
-        return new Person(modelName, modelEmail, modelStudentId, modelModuleCode, modelTutorialClass, modelTags);
+        return new Person(modelName, modelEmail, modelStudentId, modelTags);
     }
 
 }

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -53,8 +53,6 @@ public class PersonCard extends UiPart<Region> {
         name.setText(person.getName().fullName);
         email.setText(person.getEmail().value);
         stuId.setText(person.getStudentId().value);
-        module.setText(person.getModule().value);
-        tutorial.setText(person.getTutorialClass().value);
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -4,10 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.MODULE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.STUDENT_ID_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.TUTORIAL_DESC_AMY;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.AMY;
 
@@ -166,7 +164,7 @@ public class LogicManagerTest {
 
         // Triggers the saveAddressBook method by executing an add command
         String addCommand = AddCommand.COMMAND_WORD + NAME_DESC_AMY
-                + EMAIL_DESC_AMY + STUDENT_ID_DESC_AMY + MODULE_DESC_AMY + TUTORIAL_DESC_AMY;
+                + EMAIL_DESC_AMY + STUDENT_ID_DESC_AMY;
         Person expectedPerson = new PersonBuilder(AMY).withTags().build();
         ModelManager expectedModel = new ModelManager();
         expectedModel.addPerson(expectedPerson);

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -54,7 +54,6 @@ public class CommandTestUtil {
     public static final String STUDENT_ID_DESC_AMY = " " + PREFIX_STUDENTID + VALID_STUDENT_ID_AMY;
     public static final String STUDENT_ID_DESC_BOB = " " + PREFIX_STUDENTID + VALID_STUDENT_ID_BOB;
     public static final String MODULE_DESC_AMY = " " + PREFIX_MODULECODE + VALID_MODULE_AMY;
-    public static final String MODULE_DESC_BOB = " " + PREFIX_MODULECODE + VALID_MODULE_BOB;
     public static final String TUTORIAL_DESC_AMY = " " + PREFIX_TUTORIALCLASS + VALID_TUTORIAL_AMY;
     public static final String TUTORIAL_DESC_BOB = " " + PREFIX_TUTORIALCLASS + VALID_TUTORIAL_BOB;
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
@@ -69,9 +68,6 @@ public class CommandTestUtil {
     // missing '@' symbol
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo";
 
-    // empty string not allowed for module code
-    public static final String INVALID_MODULE_DESC = " " + PREFIX_MODULECODE;
-
     // invalid format for tutorial, alphabet not allowed in between 2 numbers.
     public static final String INVALID_TUTORIAL_DESC = " " + PREFIX_TUTORIALCLASS + "T1X312";
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
@@ -84,10 +80,10 @@ public class CommandTestUtil {
 
     static {
         DESC_AMY = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
-                .withStudentId(VALID_STUDENT_ID_AMY).withEmail(VALID_EMAIL_AMY).withModuleCode(VALID_MODULE_AMY)
+                .withStudentId(VALID_STUDENT_ID_AMY).withEmail(VALID_EMAIL_AMY)
                 .withTags(VALID_TAG_FRIEND).build();
         DESC_BOB = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
-                .withStudentId(VALID_STUDENT_ID_BOB).withEmail(VALID_EMAIL_BOB).withModuleCode(VALID_MODULE_BOB)
+                .withStudentId(VALID_STUDENT_ID_BOB).withEmail(VALID_EMAIL_BOB)
                 .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
     }
 

--- a/src/test/java/seedu/address/logic/commands/EditPersonDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditPersonDescriptorTest.java
@@ -6,9 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_STUDENT_ID_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 
 import org.junit.jupiter.api.Test;
@@ -40,17 +38,13 @@ public class EditPersonDescriptorTest {
         EditPersonDescriptor editedAmy = new EditPersonDescriptorBuilder(DESC_AMY).withName(VALID_NAME_BOB).build();
         assertFalse(DESC_AMY.equals(editedAmy));
 
-        // different phone -> returns false
-        editedAmy = new EditPersonDescriptorBuilder(DESC_AMY).withStudentId(VALID_STUDENT_ID_BOB).build();
-        assertFalse(DESC_AMY.equals(editedAmy));
-
         // different email -> returns false
         editedAmy = new EditPersonDescriptorBuilder(DESC_AMY).withEmail(VALID_EMAIL_BOB).build();
         assertFalse(DESC_AMY.equals(editedAmy));
 
-        // different address -> returns false
-        editedAmy = new EditPersonDescriptorBuilder(DESC_AMY).withModuleCode(VALID_MODULE_BOB).build();
-        assertFalse(DESC_AMY.equals(editedAmy));
+        // same student id -> returns true
+        editedAmy = new EditPersonDescriptorBuilder(DESC_AMY).build();
+        assertTrue(DESC_AMY.equals(editedAmy));
 
         // different tags -> returns false
         editedAmy = new EditPersonDescriptorBuilder(DESC_AMY).withTags(VALID_TAG_HUSBAND).build();
@@ -63,9 +57,7 @@ public class EditPersonDescriptorTest {
         String expected = EditPersonDescriptor.class.getCanonicalName() + "{name="
                 + editPersonDescriptor.getName().orElse(null) + ", email="
                 + editPersonDescriptor.getEmail().orElse(null) + ", studentID="
-                + editPersonDescriptor.getStudentId().orElse(null) + ", module="
-                + editPersonDescriptor.getModuleCode().orElse(null) + ", tutorial="
-                + editPersonDescriptor.getTutorialClass().orElse(null) + ", tags="
+                + editPersonDescriptor.getStudentId().orElse(null) + ", tags="
                 + editPersonDescriptor.getTags().orElse(null) + "}";
         assertEquals(expected, editPersonDescriptor.toString());
     }

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -4,12 +4,9 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_MODULE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_STUDENT_ID_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.MODULE_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.MODULE_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
@@ -18,19 +15,15 @@ import static seedu.address.logic.commands.CommandTestUtil.STUDENT_ID_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.STUDENT_ID_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
-import static seedu.address.logic.commands.CommandTestUtil.TUTORIAL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.TUTORIAL_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_STUDENT_ID_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULECODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIALCLASS;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalPersons.AMY;
@@ -40,7 +33,6 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.AddCommand;
-import seedu.address.model.module.ModuleCode;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
@@ -57,7 +49,7 @@ public class AddCommandParserTest {
 
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + EMAIL_DESC_BOB + STUDENT_ID_DESC_BOB
-                + MODULE_DESC_BOB + TUTORIAL_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedPerson));
+                + TAG_DESC_FRIEND, new AddCommand(expectedPerson));
 
 
         // multiple tags - all accepted
@@ -65,20 +57,19 @@ public class AddCommandParserTest {
                 .build();
         assertParseSuccess(parser,
                 NAME_DESC_BOB + EMAIL_DESC_BOB + STUDENT_ID_DESC_BOB
-                        + MODULE_DESC_BOB + TUTORIAL_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                        + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
                 new AddCommand(expectedPersonMultipleTags));
     }
 
     @Test
     public void parse_repeatedNonTagValue_failure() {
-        String validExpectedPersonString = NAME_DESC_BOB + EMAIL_DESC_BOB + STUDENT_ID_DESC_BOB
-                + MODULE_DESC_BOB + TUTORIAL_DESC_BOB + TAG_DESC_FRIEND;
+        String validExpectedPersonString = NAME_DESC_BOB + EMAIL_DESC_BOB + STUDENT_ID_DESC_BOB + TAG_DESC_FRIEND;
 
         // multiple names
         assertParseFailure(parser, NAME_DESC_AMY + validExpectedPersonString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
 
-        // multiple phones
+        // multiple student id
         assertParseFailure(parser, STUDENT_ID_DESC_AMY + validExpectedPersonString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_STUDENTID));
 
@@ -86,16 +77,13 @@ public class AddCommandParserTest {
         assertParseFailure(parser, EMAIL_DESC_AMY + validExpectedPersonString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_EMAIL));
 
-        // multiple addresses
-        assertParseFailure(parser, MODULE_DESC_AMY + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_MODULECODE));
 
         // multiple fields repeated
         assertParseFailure(parser,
                 validExpectedPersonString + EMAIL_DESC_AMY + STUDENT_ID_DESC_AMY + NAME_DESC_AMY
-                        + MODULE_DESC_AMY + TUTORIAL_DESC_AMY + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME, PREFIX_MODULECODE,
-                        PREFIX_EMAIL, PREFIX_STUDENTID, PREFIX_TUTORIALCLASS));
+                        + validExpectedPersonString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME,
+                        PREFIX_EMAIL, PREFIX_STUDENTID));
 
         // invalid value followed by valid value
 
@@ -107,13 +95,9 @@ public class AddCommandParserTest {
         assertParseFailure(parser, INVALID_EMAIL_DESC + validExpectedPersonString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_EMAIL));
 
-        // invalid phone
+        // invalid student id
         assertParseFailure(parser, INVALID_STUDENT_ID_DESC + validExpectedPersonString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_STUDENTID));
-
-        // invalid address
-        assertParseFailure(parser, INVALID_MODULE_DESC + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_MODULECODE));
 
         // valid value followed by invalid value
 
@@ -125,21 +109,16 @@ public class AddCommandParserTest {
         assertParseFailure(parser, validExpectedPersonString + INVALID_EMAIL_DESC,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_EMAIL));
 
-        // invalid phone
+        // invalid student id
         assertParseFailure(parser, validExpectedPersonString + INVALID_STUDENT_ID_DESC,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_STUDENTID));
-
-        // invalid address
-        assertParseFailure(parser, validExpectedPersonString + INVALID_MODULE_DESC,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_MODULECODE));
     }
 
     @Test
     public void parse_optionalFieldsMissing_success() {
         // zero tags
         Person expectedPerson = new PersonBuilder(AMY).withTags().build();
-        assertParseSuccess(parser, NAME_DESC_AMY + EMAIL_DESC_AMY + STUDENT_ID_DESC_AMY
-                        + MODULE_DESC_AMY + TUTORIAL_DESC_AMY,
+        assertParseSuccess(parser, NAME_DESC_AMY + EMAIL_DESC_AMY + STUDENT_ID_DESC_AMY,
                 new AddCommand(expectedPerson));
     }
 
@@ -148,56 +127,48 @@ public class AddCommandParserTest {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
 
         // missing name prefix
-        assertParseFailure(parser, VALID_NAME_BOB + EMAIL_DESC_BOB + STUDENT_ID_DESC_BOB + MODULE_DESC_BOB,
+        assertParseFailure(parser, VALID_NAME_BOB + EMAIL_DESC_BOB + STUDENT_ID_DESC_BOB,
                 expectedMessage);
 
-        // missing phone prefix
-        assertParseFailure(parser, NAME_DESC_BOB + EMAIL_DESC_BOB + VALID_STUDENT_ID_BOB + MODULE_DESC_BOB,
+        // missing student id prefix
+        assertParseFailure(parser, NAME_DESC_BOB + EMAIL_DESC_BOB + VALID_STUDENT_ID_BOB,
                 expectedMessage);
 
         // missing email prefix
-        assertParseFailure(parser, NAME_DESC_BOB + VALID_EMAIL_BOB + STUDENT_ID_DESC_BOB + MODULE_DESC_BOB,
-                expectedMessage);
-
-        // missing address prefix
-        assertParseFailure(parser, NAME_DESC_BOB + EMAIL_DESC_BOB + STUDENT_ID_DESC_BOB + VALID_MODULE_BOB,
+        assertParseFailure(parser, NAME_DESC_BOB + VALID_EMAIL_BOB + STUDENT_ID_DESC_BOB,
                 expectedMessage);
 
         // all prefixes missing
-        assertParseFailure(parser, VALID_NAME_BOB + VALID_EMAIL_BOB + VALID_STUDENT_ID_BOB + VALID_MODULE_BOB,
+        assertParseFailure(parser, VALID_NAME_BOB + VALID_EMAIL_BOB + VALID_STUDENT_ID_BOB,
                 expectedMessage);
     }
 
     @Test
     public void parse_invalidValue_failure() {
         // invalid name
-        assertParseFailure(parser, INVALID_NAME_DESC + EMAIL_DESC_BOB + STUDENT_ID_DESC_BOB + MODULE_DESC_BOB
-                + TUTORIAL_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Name.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, INVALID_NAME_DESC + EMAIL_DESC_BOB + STUDENT_ID_DESC_BOB
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Name.MESSAGE_CONSTRAINTS);
 
         // invalid studentId
-        assertParseFailure(parser, NAME_DESC_BOB + EMAIL_DESC_BOB + INVALID_STUDENT_ID_DESC + MODULE_DESC_BOB
-                + TUTORIAL_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, StudentId.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, NAME_DESC_BOB + EMAIL_DESC_BOB + INVALID_STUDENT_ID_DESC
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, StudentId.MESSAGE_CONSTRAINTS);
 
         // invalid email
-        assertParseFailure(parser, NAME_DESC_BOB + INVALID_EMAIL_DESC + STUDENT_ID_DESC_BOB + MODULE_DESC_BOB
-                + TUTORIAL_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Email.MESSAGE_CONSTRAINTS);
-
-        // invalid module
-        assertParseFailure(parser, NAME_DESC_BOB + STUDENT_ID_DESC_BOB + EMAIL_DESC_BOB + INVALID_MODULE_DESC
-                + TUTORIAL_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, ModuleCode.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, NAME_DESC_BOB + INVALID_EMAIL_DESC + STUDENT_ID_DESC_BOB
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Email.MESSAGE_CONSTRAINTS);
 
         // invalid tag
-        assertParseFailure(parser, NAME_DESC_BOB + EMAIL_DESC_BOB + STUDENT_ID_DESC_BOB + MODULE_DESC_BOB
-                + TUTORIAL_DESC_BOB + INVALID_TAG_DESC + VALID_TAG_FRIEND, Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, NAME_DESC_BOB + EMAIL_DESC_BOB + STUDENT_ID_DESC_BOB
+                + INVALID_TAG_DESC + VALID_TAG_FRIEND, Tag.MESSAGE_CONSTRAINTS);
 
         // two invalid values, only first invalid value reported
-        assertParseFailure(parser, INVALID_NAME_DESC + EMAIL_DESC_BOB + STUDENT_ID_DESC_BOB
-                        + INVALID_MODULE_DESC + TUTORIAL_DESC_BOB,
+        assertParseFailure(parser, INVALID_NAME_DESC + INVALID_EMAIL_DESC + STUDENT_ID_DESC_BOB
+                        + TUTORIAL_DESC_BOB,
                 Name.MESSAGE_CONSTRAINTS);
 
         // non-empty preamble
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + EMAIL_DESC_BOB + STUDENT_ID_DESC_BOB
-                        + MODULE_DESC_BOB + TUTORIAL_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                        + TAG_DESC_FRIEND,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -4,27 +4,21 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_MODULE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_STUDENT_ID_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.MODULE_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.MODULE_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.STUDENT_ID_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.STUDENT_ID_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
-import static seedu.address.logic.commands.CommandTestUtil.TUTORIAL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_STUDENT_ID_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_STUDENT_ID_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TUTORIAL_AMY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULECODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
@@ -39,7 +33,6 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
-import seedu.address.model.module.ModuleCode;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.StudentId;
@@ -85,12 +78,11 @@ public class EditCommandParserTest {
     @Test
     public void parse_invalidValue_failure() {
         assertParseFailure(parser, "1" + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS); // invalid name
-        assertParseFailure(parser, "1" + INVALID_STUDENT_ID_DESC, StudentId.MESSAGE_CONSTRAINTS); // invalid phone
+        assertParseFailure(parser, "1" + INVALID_STUDENT_ID_DESC, StudentId.MESSAGE_CONSTRAINTS); // invalid studentid
         assertParseFailure(parser, "1" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid email
-        assertParseFailure(parser, "1" + INVALID_MODULE_DESC, ModuleCode.MESSAGE_CONSTRAINTS); // invalid address
         assertParseFailure(parser, "1" + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS); // invalid tag
 
-        // invalid phone followed by valid email
+        // invalid student id followed by valid email
         assertParseFailure(parser, "1" + INVALID_STUDENT_ID_DESC + EMAIL_DESC_AMY, StudentId.MESSAGE_CONSTRAINTS);
 
         // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code Person} being edited,
@@ -107,12 +99,11 @@ public class EditCommandParserTest {
     @Test
     public void parse_allFieldsSpecified_success() {
         Index targetIndex = INDEX_SECOND_PERSON;
-        String userInput = targetIndex.getOneBased() + NAME_DESC_AMY + STUDENT_ID_DESC_BOB
-                + EMAIL_DESC_AMY + MODULE_DESC_AMY + TUTORIAL_DESC_AMY + TAG_DESC_FRIEND;
+        String userInput = targetIndex.getOneBased() + NAME_DESC_AMY + EMAIL_DESC_AMY
+                + STUDENT_ID_DESC_AMY + TAG_DESC_FRIEND;
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
-                .withStudentId(VALID_STUDENT_ID_BOB).withEmail(VALID_EMAIL_AMY).withModuleCode(VALID_MODULE_AMY)
-                .withTutorialClass(VALID_TUTORIAL_AMY).withTags(VALID_TAG_FRIEND).build();
+                .withEmail(VALID_EMAIL_AMY).withStudentId(VALID_STUDENT_ID_AMY).withTags(VALID_TAG_FRIEND).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
@@ -139,7 +130,7 @@ public class EditCommandParserTest {
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
-        // phone
+        // student id
         userInput = targetIndex.getOneBased() + STUDENT_ID_DESC_AMY;
         descriptor = new EditPersonDescriptorBuilder().withStudentId(VALID_STUDENT_ID_AMY).build();
         expectedCommand = new EditCommand(targetIndex, descriptor);
@@ -148,12 +139,6 @@ public class EditCommandParserTest {
         // email
         userInput = targetIndex.getOneBased() + EMAIL_DESC_AMY;
         descriptor = new EditPersonDescriptorBuilder().withEmail(VALID_EMAIL_AMY).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
-        assertParseSuccess(parser, userInput, expectedCommand);
-
-        // address
-        userInput = targetIndex.getOneBased() + MODULE_DESC_AMY;
-        descriptor = new EditPersonDescriptorBuilder().withModuleCode(VALID_MODULE_AMY).build();
         expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
@@ -181,19 +166,19 @@ public class EditCommandParserTest {
         assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_STUDENTID));
 
         // mulltiple valid fields repeated
-        userInput = targetIndex.getOneBased() + STUDENT_ID_DESC_AMY + MODULE_DESC_AMY + EMAIL_DESC_AMY
-                + TAG_DESC_FRIEND + STUDENT_ID_DESC_AMY + MODULE_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_FRIEND
-                + STUDENT_ID_DESC_BOB + MODULE_DESC_BOB + EMAIL_DESC_BOB + TAG_DESC_HUSBAND;
+        userInput = targetIndex.getOneBased() + STUDENT_ID_DESC_AMY + EMAIL_DESC_AMY
+                + TAG_DESC_FRIEND + STUDENT_ID_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_FRIEND
+                + STUDENT_ID_DESC_BOB + EMAIL_DESC_BOB;
 
         assertParseFailure(parser, userInput,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_STUDENTID, PREFIX_EMAIL, PREFIX_MODULECODE));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_STUDENTID, PREFIX_EMAIL));
 
         // multiple invalid values
-        userInput = targetIndex.getOneBased() + INVALID_STUDENT_ID_DESC + INVALID_MODULE_DESC + INVALID_EMAIL_DESC
-                + INVALID_STUDENT_ID_DESC + INVALID_MODULE_DESC + INVALID_EMAIL_DESC;
+        userInput = targetIndex.getOneBased() + INVALID_STUDENT_ID_DESC + INVALID_EMAIL_DESC
+                + INVALID_STUDENT_ID_DESC + INVALID_EMAIL_DESC;
 
         assertParseFailure(parser, userInput,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_STUDENTID, PREFIX_EMAIL, PREFIX_MODULECODE));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_STUDENTID, PREFIX_EMAIL));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/SearchStudentCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SearchStudentCommandParserTest.java
@@ -2,11 +2,9 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.MODULE_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.STUDENT_ID_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.TUTORIAL_DESC_BOB;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -16,8 +14,6 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.SearchStudentCommand;
-import seedu.address.model.module.ModuleContainsKeywordPredicate;
-import seedu.address.model.module.TutorialContainsKeywordPredicate;
 import seedu.address.model.person.EmailContainsKeywordPredicate;
 import seedu.address.model.person.NameContainsKeywordPredicate;
 import seedu.address.model.person.StudentIdContainsKeywordPredicate;
@@ -49,15 +45,6 @@ public class SearchStudentCommandParserTest {
                 new SearchStudentCommand(new EmailContainsKeywordPredicate(BOB.getEmail().value));
         assertParseSuccess(parser, EMAIL_DESC_BOB, expectedSearchStudentCommand);
 
-        // valid module code
-        expectedSearchStudentCommand =
-                new SearchStudentCommand(new ModuleContainsKeywordPredicate(BOB.getModule().value));
-        assertParseSuccess(parser, MODULE_DESC_BOB, expectedSearchStudentCommand);
-
-        // valid tutorial class
-        expectedSearchStudentCommand =
-                new SearchStudentCommand(new TutorialContainsKeywordPredicate(BOB.getTutorialClass().value));
-        assertParseSuccess(parser, TUTORIAL_DESC_BOB, expectedSearchStudentCommand);
 
         // extended preamble
         expectedSearchStudentCommand =

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -3,7 +3,7 @@ package seedu.address.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
@@ -47,7 +47,7 @@ public class AddressBookTest {
     @Test
     public void resetData_withDuplicatePersons_throwsDuplicatePersonException() {
         // Two persons with the same identity fields
-        Person editedAlice = new PersonBuilder(ALICE).withModuleCode(VALID_MODULE_BOB).withTags(VALID_TAG_HUSBAND)
+        Person editedAlice = new PersonBuilder(ALICE).withEmail(VALID_EMAIL_AMY).withTags(VALID_TAG_HUSBAND)
                 .build();
         List<Person> newPersons = Arrays.asList(ALICE, editedAlice);
         AddressBookStub newData = new AddressBookStub(newPersons);
@@ -74,7 +74,7 @@ public class AddressBookTest {
     @Test
     public void hasPerson_personWithSameIdentityFieldsInAddressBook_returnsTrue() {
         addressBook.addPerson(ALICE);
-        Person editedAlice = new PersonBuilder(ALICE).withModuleCode(VALID_MODULE_BOB).withTags(VALID_TAG_HUSBAND)
+        Person editedAlice = new PersonBuilder(ALICE).withEmail(VALID_EMAIL_AMY)
                 .build();
         assertTrue(addressBook.hasPerson(editedAlice));
     }

--- a/src/test/java/seedu/address/model/module/ModuleContainsKeywordPredicateTest.java
+++ b/src/test/java/seedu/address/model/module/ModuleContainsKeywordPredicateTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.testutil.PersonBuilder;
+import seedu.address.testutil.ModuleBuilder;
 
 public class ModuleContainsKeywordPredicateTest {
 
@@ -40,39 +40,35 @@ public class ModuleContainsKeywordPredicateTest {
     public void test_nameContainsKeywords_returnsTrue() {
         // One keyword
         ModuleContainsKeywordPredicate predicate = new ModuleContainsKeywordPredicate("CS2101");
-        assertTrue(predicate.test(new PersonBuilder().withModuleCode("CS2101").build()));
+        assertTrue(predicate.test(new ModuleBuilder().withModuleCode("CS2101").build()));
 
         // Partial keyword
         predicate = new ModuleContainsKeywordPredicate("CS");
-        assertTrue(predicate.test(new PersonBuilder().withModuleCode("CS2101").build()));
+        assertTrue(predicate.test(new ModuleBuilder().withModuleCode("CS2101").build()));
 
         // Mixed-case keywords
         predicate = new ModuleContainsKeywordPredicate("cs2101");
-        assertTrue(predicate.test(new PersonBuilder().withModuleCode("CS2101").build()));
+        assertTrue(predicate.test(new ModuleBuilder().withModuleCode("CS2101").build()));
     }
 
     @Test
     public void test_nameDoesNotContainKeywords_returnsFalse() {
         // Non-matching keyword
         ModuleContainsKeywordPredicate predicate = new ModuleContainsKeywordPredicate("CS2103T");
-        assertFalse(predicate.test(new PersonBuilder().withModuleCode("CS2101").build()));
+        assertFalse(predicate.test(new ModuleBuilder().withModuleCode("CS2101").build()));
 
-        // Keyword matches name but does not match module code
-        predicate = new ModuleContainsKeywordPredicate("Alice");
-        assertFalse(predicate.test(new PersonBuilder().withModuleCode("CS2101").withName("Alice").build()));
+        // Keyword matches tutorial class but does not match module code
+        predicate = new ModuleContainsKeywordPredicate("T03");
+        assertFalse(predicate.test(new ModuleBuilder().withModuleCode("CS2101").withTutorialClasses("T03").build()));
 
-        // Keyword matches email but does not match module code
-        predicate = new ModuleContainsKeywordPredicate("alice@gmail.com");
-        assertFalse(predicate.test(new PersonBuilder().withModuleCode("CS2101")
-                .withEmail("alice@gmail.com").build()));
-
-        // Keyword matches student id but does not match module code
-        predicate = new ModuleContainsKeywordPredicate("A1234567Z");
-        assertFalse(predicate.test(new PersonBuilder().withModuleCode("CS2101").withStudentId("A1234567Z").build()));
+        // Keyword matches tutorialClass but does not match module code
+        predicate = new ModuleContainsKeywordPredicate("T02");
+        assertFalse(predicate.test(new ModuleBuilder().withModuleCode("CS2101")
+                .withTutorialClasses("T02").build()));
 
         // Keyword matches tutorial class but does not match module code
         predicate = new ModuleContainsKeywordPredicate("T01");
-        assertFalse(predicate.test(new PersonBuilder().withModuleCode("CS2101").withTutorialClass("T01").build()));
+        assertFalse(predicate.test(new ModuleBuilder().withModuleCode("CS2101").withTutorialClasses("T01").build()));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/module/TutorialClassTest.java
+++ b/src/test/java/seedu/address/model/module/TutorialClassTest.java
@@ -7,6 +7,8 @@ import static seedu.address.model.module.TutorialClass.isValidTutorialClass;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.testutil.ModuleBuilder;
+
 public class TutorialClassTest {
 
     public static final String VALID_TUTORIAL = "T09";
@@ -41,6 +43,35 @@ public class TutorialClassTest {
     @Test
     void isValidTutorialClass_failure() {
         assertFalse(isValidTutorialClass(INVALID_TUTORIAL));
+    }
+
+    @Test
+    void isSameTutorialClass() {
+        ModuleCode module = new ModuleBuilder().withModuleCode("CS2102").withTutorialClasses(VALID_TUTORIAL).build();
+        TutorialClass tutorialClass = module.getTutorialClasses().get(1);
+        String tutorialClassString = tutorialClass.value;
+        assertTrue(VALID_TUTORIAL.equals(tutorialClassString));
+
+        // different module but same tutorial class notation
+        module = new ModuleBuilder().withModuleCode("CS2105").withTutorialClasses(VALID_TUTORIAL).build();
+        tutorialClass = module.getTutorialClasses().get(1);
+        tutorialClassString = tutorialClass.value;
+        assertTrue(VALID_TUTORIAL.equals(tutorialClassString));
+    }
+
+    @Test
+    void isDifferentTutorialClass() {
+        // same module but different tutorial class
+        ModuleCode module = new ModuleBuilder().withModuleCode("CS2102").withTutorialClasses(VALID_TUTORIAL).build();
+        TutorialClass tutorialClass = module.getTutorialClasses().get(0);
+        String tutorialClassString = tutorialClass.value;
+        assertFalse(VALID_TUTORIAL.equals(tutorialClassString));
+
+        // different module and different tutorial class
+        module = new ModuleBuilder().withModuleCode("CS2109").withTutorialClasses("T05").build();
+        tutorialClass = module.getTutorialClasses().get(1);
+        String tutorialClassToCompare = tutorialClass.value;
+        assertFalse(tutorialClassString.equals(tutorialClassToCompare));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/module/TutorialClassTest.java
+++ b/src/test/java/seedu/address/model/module/TutorialClassTest.java
@@ -4,10 +4,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.model.module.TutorialClass.isValidTutorialClass;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+
+import java.util.ArrayList;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.person.Person;
 import seedu.address.testutil.ModuleBuilder;
+import seedu.address.testutil.PersonBuilder;
 
 public class TutorialClassTest {
 
@@ -72,6 +77,15 @@ public class TutorialClassTest {
         tutorialClass = module.getTutorialClasses().get(1);
         String tutorialClassToCompare = tutorialClass.value;
         assertFalse(tutorialClassString.equals(tutorialClassToCompare));
+    }
+
+    @Test
+    void createTutorialClassWithExistingListOfStudentsSuccess() {
+        ArrayList<Person> listOfStudents = new ArrayList<>();
+        Person alice = new PersonBuilder(ALICE).build();
+        listOfStudents.add(alice);
+        TutorialClass tutorialClass = new TutorialClass(VALID_TUTORIAL, listOfStudents);
+        assertTrue(tutorialClass.getStudents().equals(listOfStudents));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/module/TutorialContainsKeywordPredicateTest.java
+++ b/src/test/java/seedu/address/model/module/TutorialContainsKeywordPredicateTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.testutil.PersonBuilder;
+import seedu.address.testutil.ModuleBuilder;
 
 public class TutorialContainsKeywordPredicateTest {
 
@@ -38,41 +38,50 @@ public class TutorialContainsKeywordPredicateTest {
 
     @Test
     public void test_nameContainsKeywords_returnsTrue() {
+        String tutorialClass = "T01";
+
         // One keyword
-        TutorialContainsKeywordPredicate predicate = new TutorialContainsKeywordPredicate("T01");
-        assertTrue(predicate.test(new PersonBuilder().withTutorialClass("T01").build()));
+        TutorialContainsKeywordPredicate predicate = new TutorialContainsKeywordPredicate(tutorialClass);
+        ModuleCode moduleUnderTest = new ModuleBuilder().withTutorialClasses(tutorialClass).build();
+        TutorialClass tutorialClassUnderTest = moduleUnderTest.getTutorialClasses().get(0);
+        assertTrue(predicate.test(tutorialClassUnderTest));
 
         // Partial keyword
         predicate = new TutorialContainsKeywordPredicate("1");
-        assertTrue(predicate.test(new PersonBuilder().withTutorialClass("T01").build()));
+        ModuleCode moduleUnderTestPartial = new ModuleBuilder().withTutorialClasses(tutorialClass).build();
+        TutorialClass tutorialClassUnderTestPartial = moduleUnderTestPartial.getTutorialClasses().get(0);
+        assertTrue(predicate.test(tutorialClassUnderTestPartial));
 
         // Mixed-case keywords
         predicate = new TutorialContainsKeywordPredicate("t01");
-        assertTrue(predicate.test(new PersonBuilder().withTutorialClass("T01").build()));
+        ModuleCode moduleUnderTestMixed = new ModuleBuilder().withTutorialClasses(tutorialClass).build();
+        TutorialClass tutorialClassUnderTestMixed = moduleUnderTestMixed.getTutorialClasses().get(0);
+        assertTrue(predicate.test(tutorialClassUnderTestMixed));
     }
 
     @Test
     public void test_nameDoesNotContainKeywords_returnsFalse() {
+        String defaultTutorialClass = "T01";
+
         // Non-matching keyword
         TutorialContainsKeywordPredicate predicate = new TutorialContainsKeywordPredicate("T15");
-        assertFalse(predicate.test(new PersonBuilder().withTutorialClass("T01").build()));
-
-        // Keyword matches name but does not match tutorial class
-        predicate = new TutorialContainsKeywordPredicate("Alice");
-        assertFalse(predicate.test(new PersonBuilder().withTutorialClass("T01").withName("Alice").build()));
-
-        // Keyword matches email but does not match tutorial class
-        predicate = new TutorialContainsKeywordPredicate("alice@gmail.com");
-        assertFalse(predicate.test(new PersonBuilder().withTutorialClass("T01")
-                .withEmail("alice@gmail.com").build()));
-
-        // Keyword matches student id but does not match tutorial class
-        predicate = new TutorialContainsKeywordPredicate("A1234567Z");
-        assertFalse(predicate.test(new PersonBuilder().withTutorialClass("T01").withStudentId("A1234567Z").build()));
+        ModuleCode moduleUnderTest = new ModuleBuilder().withTutorialClasses(defaultTutorialClass).build();
+        TutorialClass tutorialClassUnderTest = moduleUnderTest.getTutorialClasses().get(0);
+        assertFalse(predicate.test(tutorialClassUnderTest));
 
         // Keyword matches module code but does not match tutorial class
-        predicate = new TutorialContainsKeywordPredicate("CS2101");
-        assertFalse(predicate.test(new PersonBuilder().withTutorialClass("T01").withModuleCode("CS2101").build()));
+        predicate = new TutorialContainsKeywordPredicate("CS2100");
+        ModuleCode moduleUnderTestModuleMatch = new ModuleBuilder().withModuleCode("CS2100")
+                .withTutorialClasses(defaultTutorialClass).build();
+        TutorialClass tutorialClassUnderTestModuleMatch = moduleUnderTestModuleMatch.getTutorialClasses().get(0);
+        assertFalse(predicate.test(tutorialClassUnderTestModuleMatch));
+
+        // Keyword matches tutorial class but does not match module code
+        predicate = new TutorialContainsKeywordPredicate("T03");
+        ModuleCode moduleUnderTestClassMatch = new ModuleBuilder().withModuleCode("CS2100")
+                .withTutorialClasses(defaultTutorialClass).build();
+        TutorialClass tutorialClassUnderTestClassMatch = moduleUnderTestClassMatch.getTutorialClasses().get(0);
+        assertFalse(predicate.test(tutorialClassUnderTestClassMatch));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/EmailContainsKeywordPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/EmailContainsKeywordPredicateTest.java
@@ -64,13 +64,14 @@ public class EmailContainsKeywordPredicateTest {
         predicate = new EmailContainsKeywordPredicate("Alice");
         assertFalse(predicate.test(new PersonBuilder().withEmail("al1c3@gmail.com").withName("Alice").build()));
 
-        // Keyword matches module code but does not match email
-        predicate = new EmailContainsKeywordPredicate("CS2101");
-        assertFalse(predicate.test(new PersonBuilder().withEmail("alice@gmail.com").withModuleCode("CS2101").build()));
+        // Keyword matches student id but does not match email
+        predicate = new EmailContainsKeywordPredicate("A1234567A");
+        assertFalse(predicate.test(new PersonBuilder().withEmail("alice@gmail.com")
+                .withStudentId("A1234567A").build()));
 
-        // Keyword matches tutorial class but does not match email
-        predicate = new EmailContainsKeywordPredicate("T01");
-        assertFalse(predicate.test(new PersonBuilder().withEmail("alice@gmail.com").withTutorialClass("T01").build()));
+        // Keyword matches name but does not match email
+        predicate = new EmailContainsKeywordPredicate("Bob");
+        assertFalse(predicate.test(new PersonBuilder().withEmail("alice@gmail.com").withName("Bob").build()));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/NameContainsKeywordPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/NameContainsKeywordPredicateTest.java
@@ -68,13 +68,13 @@ public class NameContainsKeywordPredicateTest {
         predicate = new NameContainsKeywordPredicate("alice@gmail.com");
         assertFalse(predicate.test(new PersonBuilder().withName("Alice").withEmail("alice@gmail.com").build()));
 
-        // Keyword matches module code but does not match name
-        predicate = new NameContainsKeywordPredicate("CS2101");
-        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withModuleCode("CS2101").build()));
+        // Keyword matches student id but does not match name
+        predicate = new NameContainsKeywordPredicate("A7654321Z");
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withStudentId("A7654321Z").build()));
 
-        // Keyword matches tutorial class but does not match name
-        predicate = new NameContainsKeywordPredicate("T01");
-        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withTutorialClass("T01").build()));
+        // Keyword matches email but does not match name
+        predicate = new NameContainsKeywordPredicate("bob@gmail.com");
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withEmail("bob@gmail.com").build()));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
@@ -68,10 +68,10 @@ public class NameContainsKeywordsPredicateTest {
         predicate = new NameContainsKeywordsPredicate(Arrays.asList("Carol"));
         assertFalse(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
-        // Keywords match phone, email and address, but does not match name
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("A1234567Z", "alice@email.com", "CS2106", "T01"));
+        // Keywords match student id, email, but does not match name
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("A1234567Z", "alice@email.com"));
         assertFalse(predicate.test(new PersonBuilder().withName("Alice").withStudentId("A1234567Z")
-                .withTutorialClass("T01").withEmail("alice@email.com").withModuleCode("CS2106").build()));
+                .withEmail("alice@email.com").build()));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -4,9 +4,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_STUDENT_ID_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
@@ -34,7 +34,7 @@ public class PersonTest {
 
         // same studentId, all other attributes different -> returns true
         Person editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).withEmail(VALID_EMAIL_BOB)
-                .withModuleCode(VALID_MODULE_BOB).withTags(VALID_TAG_HUSBAND).build();
+                .withTags(VALID_TAG_FRIEND).build();
         assertTrue(ALICE.isSamePerson(editedAlice));
 
         // different studentId, all other attributes same -> returns false
@@ -64,16 +64,12 @@ public class PersonTest {
         Person editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).build();
         assertFalse(ALICE.equals(editedAlice));
 
-        // different phone -> returns false
+        // different student id -> returns false
         editedAlice = new PersonBuilder(ALICE).withStudentId(VALID_STUDENT_ID_BOB).build();
         assertFalse(ALICE.equals(editedAlice));
 
         // different email -> returns false
         editedAlice = new PersonBuilder(ALICE).withEmail(VALID_EMAIL_BOB).build();
-        assertFalse(ALICE.equals(editedAlice));
-
-        // different address -> returns false
-        editedAlice = new PersonBuilder(ALICE).withModuleCode(VALID_MODULE_BOB).build();
         assertFalse(ALICE.equals(editedAlice));
 
         // different tags -> returns false
@@ -85,7 +81,6 @@ public class PersonTest {
     public void toStringMethod() {
         String expected = Person.class.getCanonicalName() + "{name=" + ALICE.getName()
                 + ", email=" + ALICE.getEmail() + ", stuId=" + ALICE.getStudentId()
-                + ", module=" + ALICE.getModule() + ", tutorial=" + ALICE.getTutorialClass()
                 + ", tags=" + ALICE.getTags() + "}";
         assertEquals(expected, ALICE.toString());
     }

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -32,8 +32,18 @@ public class PersonTest {
         // null -> returns false
         assertFalse(ALICE.isSamePerson(null));
 
+        // same name, all other attributes different --> return false
+        Person editedAlice = new PersonBuilder(ALICE).withEmail(VALID_EMAIL_BOB)
+                .withStudentId(VALID_STUDENT_ID_BOB).withTags(VALID_TAG_FRIEND).build();
+        assertFalse(ALICE.isSamePerson(editedAlice));
+
+        // same email, all other attributes different --> return false
+        editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB)
+                .withStudentId(VALID_STUDENT_ID_BOB).withTags(VALID_TAG_FRIEND).build();
+        assertFalse(ALICE.isSamePerson(editedAlice));
+
         // same studentId, all other attributes different -> returns true
-        Person editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).withEmail(VALID_EMAIL_BOB)
+        editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).withEmail(VALID_EMAIL_BOB)
                 .withTags(VALID_TAG_FRIEND).build();
         assertTrue(ALICE.isSamePerson(editedAlice));
 

--- a/src/test/java/seedu/address/model/person/StudentIdContainsKeywordPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/StudentIdContainsKeywordPredicateTest.java
@@ -64,14 +64,6 @@ public class StudentIdContainsKeywordPredicateTest {
         predicate = new StudentIdContainsKeywordPredicate("alice@gmail.com");
         assertFalse(predicate.test(new PersonBuilder().withStudentId("A1234567Z")
                 .withEmail("alice@gmail.com").build()));
-
-        // Keyword matches module code but does not match student id
-        predicate = new StudentIdContainsKeywordPredicate("CS2101");
-        assertFalse(predicate.test(new PersonBuilder().withStudentId("A1234567Z").withModuleCode("CS2101").build()));
-
-        // Keyword matches tutorial class but does not match student id
-        predicate = new StudentIdContainsKeywordPredicate("T01");
-        assertFalse(predicate.test(new PersonBuilder().withStudentId("A1234567Z").withTutorialClass("T01").build()));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/UniquePersonListTest.java
+++ b/src/test/java/seedu/address/model/person/UniquePersonListTest.java
@@ -3,7 +3,9 @@ package seedu.address.model.person;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
@@ -42,7 +44,7 @@ public class UniquePersonListTest {
     @Test
     public void contains_personWithSameIdentityFieldsInList_returnsTrue() {
         uniquePersonList.add(ALICE);
-        Person editedAlice = new PersonBuilder(ALICE).withModuleCode(VALID_MODULE_BOB).withTags(VALID_TAG_HUSBAND)
+        Person editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).withTags(VALID_TAG_FRIEND)
                 .build();
         assertTrue(uniquePersonList.contains(editedAlice));
     }
@@ -85,7 +87,7 @@ public class UniquePersonListTest {
     @Test
     public void setPerson_editedPersonHasSameIdentity_success() {
         uniquePersonList.add(ALICE);
-        Person editedAlice = new PersonBuilder(ALICE).withModuleCode(VALID_MODULE_BOB).withTags(VALID_TAG_HUSBAND)
+        Person editedAlice = new PersonBuilder(ALICE).withEmail(VALID_EMAIL_BOB).withTags(VALID_TAG_HUSBAND)
                 .build();
         uniquePersonList.setPerson(ALICE, editedAlice);
         UniquePersonList expectedUniquePersonList = new UniquePersonList();

--- a/src/test/java/seedu/address/storage/JsonAdaptedModuleTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedModuleTest.java
@@ -2,7 +2,6 @@ package seedu.address.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalPersons.BENSON;
 
 import java.util.ArrayList;
 
@@ -15,7 +14,7 @@ import seedu.address.model.module.TutorialClass;
 class JsonAdaptedModuleTest {
 
     private static final String INVALID_MODULE = " ";
-    private static final String VALID_MODULE = BENSON.getModule().toString();
+    private static final String VALID_MODULE = "CS2100";
     @Test
     void toModelType_success() throws Exception {
         ModuleCode module = new ModuleCode(VALID_MODULE);

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -12,7 +12,6 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.exceptions.IllegalValueException;
-import seedu.address.model.module.ModuleCode;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.StudentId;
@@ -29,8 +28,6 @@ public class JsonAdaptedPersonTest {
     private static final String VALID_NAME = BENSON.getName().toString();
     private static final String VALID_STUDENT_ID = BENSON.getStudentId().toString();
     private static final String VALID_EMAIL = BENSON.getEmail().toString();
-    private static final String VALID_MODULE = BENSON.getModule().toString();
-    private static final String VALID_TUTORIAL = BENSON.getTutorialClass().toString();
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
@@ -44,16 +41,14 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(INVALID_NAME, VALID_EMAIL, VALID_STUDENT_ID,
-                        VALID_MODULE, VALID_TUTORIAL, VALID_TAGS);
+                new JsonAdaptedPerson(INVALID_NAME, VALID_EMAIL, VALID_STUDENT_ID, VALID_TAGS);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_EMAIL, VALID_STUDENT_ID,
-                VALID_MODULE, VALID_TUTORIAL, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_EMAIL, VALID_STUDENT_ID, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -61,16 +56,14 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidStudentId_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_EMAIL, INVALID_STUDENT_ID,
-                        VALID_MODULE, VALID_TUTORIAL, VALID_TAGS);
+                new JsonAdaptedPerson(VALID_NAME, VALID_EMAIL, INVALID_STUDENT_ID, VALID_TAGS);
         String expectedMessage = StudentId.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullStudentId_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_EMAIL, null,
-                VALID_MODULE, VALID_TUTORIAL, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_EMAIL, null, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, StudentId.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -78,34 +71,15 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, INVALID_EMAIL, VALID_STUDENT_ID,
-                        VALID_MODULE, VALID_TUTORIAL, VALID_TAGS);
+                new JsonAdaptedPerson(VALID_NAME, INVALID_EMAIL, VALID_STUDENT_ID, VALID_TAGS);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_STUDENT_ID,
-                VALID_MODULE, VALID_TUTORIAL, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_STUDENT_ID, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
-        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
-    }
-
-    @Test
-    public void toModelType_invalidModuleCode_throwsIllegalValueException() {
-        JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_EMAIL, VALID_STUDENT_ID,
-                        INVALID_MODULE, VALID_TUTORIAL, VALID_TAGS);
-        String expectedMessage = ModuleCode.MESSAGE_CONSTRAINTS;
-        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
-    }
-
-    @Test
-    public void toModelType_nullModuleCode_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_EMAIL, VALID_STUDENT_ID,
-                 null, VALID_TUTORIAL, VALID_TAGS);
-        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, ModuleCode.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
@@ -114,9 +88,7 @@ public class JsonAdaptedPersonTest {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_EMAIL, VALID_STUDENT_ID,
-                        VALID_MODULE, VALID_TUTORIAL, invalidTags);
+                new JsonAdaptedPerson(VALID_NAME, VALID_EMAIL, VALID_STUDENT_ID, invalidTags);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
-
 }

--- a/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
@@ -5,8 +5,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
-import seedu.address.model.module.ModuleCode;
-import seedu.address.model.module.TutorialClass;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
@@ -36,8 +34,6 @@ public class EditPersonDescriptorBuilder {
         descriptor.setName(person.getName());
         descriptor.setEmail(person.getEmail());
         descriptor.setStudentId(person.getStudentId());
-        descriptor.setModuleCode(person.getModule());
-        descriptor.setTutorialClass(person.getTutorialClass());
         descriptor.setTags(person.getTags());
     }
 
@@ -63,23 +59,6 @@ public class EditPersonDescriptorBuilder {
      */
     public EditPersonDescriptorBuilder withStudentId(String studentId) {
         descriptor.setStudentId(new StudentId(studentId));
-        return this;
-    }
-
-    /**
-     * Sets the {@code ModuleCode} of the {@code EditPersonDescriptor} that we are building.
-     */
-    public EditPersonDescriptorBuilder withModuleCode(String moduleCode) {
-        descriptor.setModuleCode(new ModuleCode(moduleCode));
-        return this;
-    }
-
-
-    /**
-     * Sets the {@code TutorialClass} of the {@code EditPersonDescriptor} that we are building.
-     */
-    public EditPersonDescriptorBuilder withTutorialClass(String tutorial) {
-        descriptor.setTutorialClass(new TutorialClass(tutorial));
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/ModuleBuilder.java
+++ b/src/test/java/seedu/address/testutil/ModuleBuilder.java
@@ -1,0 +1,57 @@
+package seedu.address.testutil;
+
+import java.util.ArrayList;
+
+import seedu.address.model.module.ModuleCode;
+import seedu.address.model.module.TutorialClass;
+
+/**
+ * A utility function to help with building Module objects.
+ */
+public class ModuleBuilder {
+
+    public static final String DEFAULT_MODULE = "CS1010S";
+    public static final String DEFAULT_TUTORIAL = "T01";
+
+    private ModuleCode moduleCode;
+    private ArrayList<TutorialClass> tutorialClasses;
+
+    /**
+     * Creates a {@code ModuleBuilder} with the default details.
+     */
+    public ModuleBuilder() {
+        moduleCode = new ModuleCode(DEFAULT_MODULE);
+        tutorialClasses = new ArrayList<>();
+        tutorialClasses.add(new TutorialClass(DEFAULT_TUTORIAL));
+    }
+
+    /**
+     * Initializes the ModuleBuilder with the data of {@code moduleToCopy}.
+     */
+    public ModuleBuilder(ModuleCode moduleToCopy) {
+        moduleCode = moduleToCopy.getModule();
+        tutorialClasses = moduleToCopy.getTutorialClasses();
+    }
+
+    /**
+     * Sets the {@code moduleCode} of the {@code ModuleCode} that we are building.
+     */
+    public ModuleBuilder withModuleCode(String moduleCode) {
+        this.moduleCode = new ModuleCode(moduleCode);
+        return this;
+    }
+
+    /**
+     * Sets the {@code tutorialClass} of the {@code TutorialClass} that we are building.
+     */
+    public ModuleBuilder withTutorialClasses(String tutorialClass) {
+        TutorialClass tutorialClassToAdd = new TutorialClass(tutorialClass);
+        this.tutorialClasses = new ArrayList<>();
+        this.tutorialClasses.add(tutorialClassToAdd);
+        return this;
+    }
+
+    public ModuleCode build() {
+        return new ModuleCode(moduleCode.value, tutorialClasses);
+    }
+}

--- a/src/test/java/seedu/address/testutil/ModuleBuilder.java
+++ b/src/test/java/seedu/address/testutil/ModuleBuilder.java
@@ -46,7 +46,6 @@ public class ModuleBuilder {
      */
     public ModuleBuilder withTutorialClasses(String tutorialClass) {
         TutorialClass tutorialClassToAdd = new TutorialClass(tutorialClass);
-        this.tutorialClasses = new ArrayList<>();
         this.tutorialClasses.add(tutorialClassToAdd);
         return this;
     }

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -3,8 +3,6 @@ package seedu.address.testutil;
 import java.util.HashSet;
 import java.util.Set;
 
-import seedu.address.model.module.ModuleCode;
-import seedu.address.model.module.TutorialClass;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
@@ -20,14 +18,10 @@ public class PersonBuilder {
     public static final String DEFAULT_NAME = "Amy Bee";
     public static final String DEFAULT_EMAIL = "amy@gmail.com";
     public static final String DEFAULT_STUDENT_ID = "A1111111Z";
-    public static final String DEFAULT_MODULE = "CS1010S";
-    public static final String DEFAULT_TUTORIAL = "T01";
 
     private Name name;
     private Email email;
     private StudentId studentId;
-    private ModuleCode moduleCode;
-    private TutorialClass tutorialClass;
     private Set<Tag> tags;
 
     /**
@@ -37,8 +31,6 @@ public class PersonBuilder {
         name = new Name(DEFAULT_NAME);
         email = new Email(DEFAULT_EMAIL);
         studentId = new StudentId(DEFAULT_STUDENT_ID);
-        moduleCode = new ModuleCode(DEFAULT_MODULE);
-        tutorialClass = new TutorialClass(DEFAULT_TUTORIAL);
         tags = new HashSet<>();
     }
 
@@ -49,8 +41,6 @@ public class PersonBuilder {
         name = personToCopy.getName();
         email = personToCopy.getEmail();
         studentId = personToCopy.getStudentId();
-        moduleCode = personToCopy.getModule();
-        tutorialClass = personToCopy.getTutorialClass();
         tags = new HashSet<>(personToCopy.getTags());
     }
 
@@ -86,24 +76,8 @@ public class PersonBuilder {
         return this;
     }
 
-    /**
-     * Sets the {@code ModuleCode} of the {@code Person} that we are building.
-     */
-    public PersonBuilder withModuleCode(String moduleCode) {
-        this.moduleCode = new ModuleCode(moduleCode);
-        return this;
-    }
-
-    /**
-     * Sets the {@code TutorialClass} of the {@code Person} that we are building.
-     */
-    public PersonBuilder withTutorialClass(String tutorialClass) {
-        this.tutorialClass = new TutorialClass(tutorialClass);
-        return this;
-    }
-
     public Person build() {
-        return new Person(name, email, studentId, moduleCode, tutorialClass, tags);
+        return new Person(name, email, studentId, tags);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -1,11 +1,9 @@
 package seedu.address.testutil;
 
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULECODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIALCLASS;
 
 import java.util.Set;
 
@@ -34,8 +32,6 @@ public class PersonUtil {
         sb.append(PREFIX_NAME + person.getName().fullName + " ");
         sb.append(PREFIX_EMAIL + person.getEmail().value + " ");
         sb.append(PREFIX_STUDENTID + person.getStudentId().value + " ");
-        sb.append(PREFIX_MODULECODE + person.getModule().value + " ");
-        sb.append(PREFIX_TUTORIALCLASS + person.getTutorialClass().value + " ");
         person.getTags().stream().forEach(
             s -> sb.append(PREFIX_TAG + s.tagName + " ")
         );
@@ -51,10 +47,6 @@ public class PersonUtil {
         descriptor.getEmail().ifPresent(email -> sb.append(PREFIX_EMAIL).append(email.value).append(" "));
         descriptor.getStudentId().ifPresent(studentId ->
                 sb.append(PREFIX_STUDENTID).append(studentId.value).append(" "));
-        descriptor.getModuleCode().ifPresent(moduleCode ->
-                sb.append(PREFIX_MODULECODE).append(moduleCode.value).append(" "));
-        descriptor.getTutorialClass().ifPresent(tutorialClass ->
-                sb.append(PREFIX_TUTORIALCLASS).append(tutorialClass.value).append(" "));
         if (descriptor.getTags().isPresent()) {
             Set<Tag> tags = descriptor.getTags().get();
             if (tags.isEmpty()) {

--- a/src/test/java/seedu/address/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/address/testutil/TypicalIndexes.java
@@ -9,5 +9,4 @@ public class TypicalIndexes {
     public static final Index INDEX_FIRST_PERSON = Index.fromOneBased(1);
     public static final Index INDEX_SECOND_PERSON = Index.fromOneBased(2);
     public static final Index INDEX_THIRD_PERSON = Index.fromOneBased(3);
-    public static final Index INDEX_FIRST_CLASS = Index.fromOneBased(1);
 }

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -2,16 +2,12 @@ package seedu.address.testutil;
 
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_STUDENT_ID_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_STUDENT_ID_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TUTORIAL_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TUTORIAL_BOB;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -28,37 +24,37 @@ import seedu.address.model.person.Person;
 public class TypicalPersons {
 
     public static final Person ALICE = new PersonBuilder().withName("Alice Pauline")
-            .withModuleCode("CS2105").withEmail("alice@example.com")
-            .withStudentId("A1234567A").withTutorialClass("T01")
+            .withEmail("alice@example.com")
+            .withStudentId("A1234567A")
             .withTags("friends").build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
-            .withModuleCode("CS2105")
-            .withEmail("johnd@example.com").withStudentId("A1234567B").withTutorialClass("T01")
+
+            .withEmail("johnd@example.com").withStudentId("A1234567B")
             .withTags("owesMoney", "friends").build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withStudentId("A1234567C")
-            .withTutorialClass("T01").withEmail("heinz@example.com").withModuleCode("CS2105").build();
+            .withEmail("heinz@example.com").build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withStudentId("A1234567D")
-            .withTutorialClass("T01").withEmail("cornelia@example.com").withModuleCode("CS2105").withTags("friends")
+            .withEmail("cornelia@example.com").withTags("friends")
             .build();
     public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withStudentId("A1234567E")
-            .withTutorialClass("T01").withEmail("werner@example.com").withModuleCode("CS2105").build();
+            .withEmail("werner@example.com").build();
     public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withStudentId("A1234567F")
-            .withTutorialClass("T01").withEmail("lydia@example.com").withModuleCode("CS2105").build();
+            .withEmail("lydia@example.com").build();
     public static final Person GEORGE = new PersonBuilder().withName("George Best").withStudentId("A1234567G")
-            .withTutorialClass("T01").withEmail("anna@example.com").withModuleCode("CS2105").build();
+            .withEmail("anna@example.com").build();
 
     // Manually added
     public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withStudentId("A1234567H")
-            .withTutorialClass("T01").withEmail("stefan@example.com").withModuleCode("CS2105").build();
+            .withEmail("stefan@example.com").build();
     public static final Person IDA = new PersonBuilder().withName("Ida Mueller").withStudentId("A1234567I")
-            .withTutorialClass("T01").withEmail("hans@example.com").withModuleCode("CS2105").build();
+            .withEmail("hans@example.com").build();
 
     // Manually added - Person's details found in {@code CommandTestUtil}
     public static final Person AMY = new PersonBuilder().withName(VALID_NAME_AMY).withStudentId(VALID_STUDENT_ID_AMY)
-            .withTutorialClass(VALID_TUTORIAL_AMY).withEmail(VALID_EMAIL_AMY).withModuleCode(VALID_MODULE_AMY)
+            .withEmail(VALID_EMAIL_AMY)
             .withTags(VALID_TAG_FRIEND).build();
     public static final Person BOB = new PersonBuilder().withName(VALID_NAME_BOB).withStudentId(VALID_STUDENT_ID_BOB)
-            .withTutorialClass(VALID_TUTORIAL_BOB).withEmail(VALID_EMAIL_BOB).withModuleCode(VALID_MODULE_BOB)
+            .withEmail(VALID_EMAIL_BOB)
             .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
 
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER


### PR DESCRIPTION
Fixes #6 

* Change /add_student command format from "name email id moduleCode tutorialClass" to only "name email id".

* Update add student command parser to support this change as well.

* Add a new ModuleBuilder class under the testutil folder. Serves as a utility function to create ModuleCode objects.

* Update testcases to support new changes.