### PR TITLE
Delete class command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddClassCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddClassCommand.java
@@ -14,7 +14,7 @@ import seedu.address.model.module.TutorialClass;
  * A class that handles the /add_class command execution.
  */
 public class AddClassCommand extends Command {
-    public static final String MESSAGE_ADD_REMARK_SUCCESS = "Added %1$s %2$s";
+    public static final String MESSAGE_ADD_CLASS_SUCCESS = "Added %1$s %2$s";
     public static final String MESSAGE_DUPLICATE_CLASS = "%1$s %2$s already added!";
     public static final String COMMAND_WORD = "/add_class";
 
@@ -60,7 +60,7 @@ public class AddClassCommand extends Command {
      * {@code personToEdit}.
      */
     private String generateSuccessMessage(ModuleCode module, TutorialClass tutorialString) {
-        return String.format(MESSAGE_ADD_REMARK_SUCCESS, module.toString(), tutorialString.toString());
+        return String.format(MESSAGE_ADD_CLASS_SUCCESS, module.toString(), tutorialString.toString());
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteClassCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteClassCommand.java
@@ -2,7 +2,6 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
-import static seedu.address.logic.commands.AddClassCommand.MESSAGE_ADD_CLASS_SUCCESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULECODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIALCLASS;
 
@@ -11,13 +10,17 @@ import seedu.address.model.Model;
 import seedu.address.model.module.ModuleCode;
 import seedu.address.model.module.TutorialClass;
 
+/**
+ * A class used to handle the deletion of tutorial classes.
+ */
 public class DeleteClassCommand extends Command {
     public static final String MESSAGE_DELETE_CLASS_SUCCESS = "Removed %1$s %2$s!";
     public static final String MESSAGE_MODULE_NOT_FOUND = "%1$s not in list!";
     public static final String MESSAGE_CLASS_NOT_FOUND = "%1$s %2$s not in list!";
     public static final String COMMAND_WORD = "/delete_class";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Deletes a class with the module code and tutorial class specified\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Deletes a class with the module code and tutorial class specified\n"
             + "Parameters:" + PREFIX_MODULECODE + "MODULE_CODE (must be a String) "
             + PREFIX_TUTORIALCLASS + "TUTORIAL_CLASS (must be a String)"
             + "Example: " + COMMAND_WORD + PREFIX_MODULECODE + " CS2103T "
@@ -41,7 +44,6 @@ public class DeleteClassCommand extends Command {
 
         ModuleCode existingModule = model.findModuleFromList(module);
         if (existingModule == null) {
-            new ListClassesCommand();
             String moduleNotFoundMessage = String.format(MESSAGE_MODULE_NOT_FOUND, module);
             throw new CommandException(moduleNotFoundMessage);
         }

--- a/src/main/java/seedu/address/logic/commands/DeleteClassCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteClassCommand.java
@@ -1,0 +1,83 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.commands.AddClassCommand.MESSAGE_ADD_CLASS_SUCCESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULECODE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIALCLASS;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.module.ModuleCode;
+import seedu.address.model.module.TutorialClass;
+
+public class DeleteClassCommand extends Command {
+    public static final String MESSAGE_DELETE_CLASS_SUCCESS = "Removed %1$s %2$s!";
+    public static final String MESSAGE_MODULE_NOT_FOUND = "%1$s not in list!";
+    public static final String MESSAGE_CLASS_NOT_FOUND = "%1$s %2$s not in list!";
+    public static final String COMMAND_WORD = "/delete_class";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Deletes a class with the module code and tutorial class specified\n"
+            + "Parameters:" + PREFIX_MODULECODE + "MODULE_CODE (must be a String) "
+            + PREFIX_TUTORIALCLASS + "TUTORIAL_CLASS (must be a String)"
+            + "Example: " + COMMAND_WORD + PREFIX_MODULECODE + " CS2103T "
+            + PREFIX_TUTORIALCLASS + "T09";
+
+    private final ModuleCode module;
+    private final TutorialClass tutorialString;
+
+    /**
+     * @param module of the tutorial class to be added
+     */
+    public DeleteClassCommand(ModuleCode module, TutorialClass tutorialClass) {
+        requireAllNonNull(module);
+        this.module = module;
+        this.tutorialString = tutorialClass;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        ModuleCode existingModule = model.findModuleFromList(module);
+        if (existingModule == null) {
+            new ListClassesCommand();
+            String moduleNotFoundMessage = String.format(MESSAGE_MODULE_NOT_FOUND, module);
+            throw new CommandException(moduleNotFoundMessage);
+        }
+
+        if (!(existingModule.hasTutorialClass(tutorialString))) {
+            String classNotFoundMessage = String.format(MESSAGE_CLASS_NOT_FOUND, module, tutorialString);
+            String tutorialList = existingModule.listTutorialClasses();
+            throw new CommandException(classNotFoundMessage + "\n" + tutorialList);
+        } else {
+            existingModule.deleteTutorialClass(tutorialString);
+        }
+
+        return new CommandResult(generateSuccessMessage(module, tutorialString));
+    }
+
+    /**
+     * Generates a command execution success message based on whether the removed from
+     * {@code personToEdit}.
+     */
+    private String generateSuccessMessage(ModuleCode module, TutorialClass tutorialString) {
+        return String.format(MESSAGE_DELETE_CLASS_SUCCESS, module.toString(), tutorialString.toString());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof DeleteClassCommand)) {
+            return false;
+        }
+
+        DeleteClassCommand e = (DeleteClassCommand) other;
+        return module.equals(e.module);
+    }
+}
+

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -12,6 +12,7 @@ import seedu.address.logic.commands.AddClassCommand;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.DeleteClassCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
@@ -69,6 +70,9 @@ public class AddressBookParser {
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();
+
+        case DeleteClassCommand.COMMAND_WORD:
+            return new DeleteClassCommandParser().parse(arguments);
 
         case DeleteStudentCommand.COMMAND_WORD:
             return new DeleteStudentCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/DeleteClassCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteClassCommandParser.java
@@ -1,0 +1,49 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULECODE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIALCLASS;
+
+import java.util.stream.Stream;
+
+import seedu.address.logic.commands.DeleteClassCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.module.ModuleCode;
+import seedu.address.model.module.TutorialClass;
+
+
+
+/**
+ * Parses input arguments and creates a new {@code RemarkCommand} object
+ */
+public class DeleteClassCommandParser implements Parser<DeleteClassCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the {@code RemarkCommand}
+     * and returns a {@code RemarkCommand} object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public DeleteClassCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_MODULECODE, PREFIX_TUTORIALCLASS);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_MODULECODE, PREFIX_TUTORIALCLASS)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteClassCommand.MESSAGE_USAGE));
+        }
+
+        String moduleCode = argMultimap.getValue(PREFIX_MODULECODE).orElse("");
+        String tutorialClass = argMultimap.getValue(PREFIX_TUTORIALCLASS).orElse("");
+        if (!(ModuleCode.isValidModuleCode(moduleCode))) {
+            throw new ParseException(ModuleCode.MESSAGE_CONSTRAINTS);
+        }
+        if (!(TutorialClass.isValidTutorialClass(tutorialClass))) {
+            throw new ParseException(TutorialClass.MESSAGE_CONSTRAINTS);
+        }
+        return new DeleteClassCommand(new ModuleCode(moduleCode), new TutorialClass(tutorialClass));
+    }
+
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+}

--- a/src/main/java/seedu/address/model/module/ModuleCode.java
+++ b/src/main/java/seedu/address/model/module/ModuleCode.java
@@ -20,7 +20,7 @@ public class ModuleCode {
      */
     public static final String VALIDATION_REGEX = "^[A-Z]{2,3}\\d{4}[A-Z]?$";
 
-    public final String value;
+    public final String moduleCode;
     private final ArrayList<TutorialClass> tutorialClasses;
 
     /**
@@ -31,7 +31,7 @@ public class ModuleCode {
     public ModuleCode(String moduleCode) {
         requireAllNonNull(moduleCode);
         checkArgument(isValidModuleCode(moduleCode), MESSAGE_CONSTRAINTS);
-        this.value = moduleCode;
+        this.moduleCode = moduleCode;
         this.tutorialClasses = new ArrayList<TutorialClass>();
     }
 
@@ -45,7 +45,7 @@ public class ModuleCode {
     public ModuleCode(String moduleCode, String tutorialClass) {
         requireAllNonNull(moduleCode);
         checkArgument(isValidModuleCode(moduleCode), MESSAGE_CONSTRAINTS);
-        this.value = moduleCode;
+        this.moduleCode = moduleCode;
         this.tutorialClasses = new ArrayList<TutorialClass>();
         tutorialClasses.add(new TutorialClass(tutorialClass));
     }
@@ -60,7 +60,7 @@ public class ModuleCode {
     public ModuleCode(String moduleCode, ArrayList<TutorialClass> tutorialClasses) {
         requireAllNonNull(moduleCode);
         checkArgument(isValidModuleCode(moduleCode), MESSAGE_CONSTRAINTS);
-        this.value = moduleCode;
+        this.moduleCode = moduleCode;
         this.tutorialClasses = tutorialClasses;
     }
 
@@ -90,7 +90,7 @@ public class ModuleCode {
 
     @Override
     public String toString() {
-        return value;
+        return moduleCode;
     }
 
     @Override
@@ -105,23 +105,23 @@ public class ModuleCode {
         }
 
         ModuleCode otherModuleCode = (ModuleCode) other;
-        return value.equals(otherModuleCode.value);
+        return moduleCode.equals(otherModuleCode.moduleCode);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return moduleCode.hashCode();
     }
 
     /**
      * Checks if the given tutorial class is already in the list.
      *
-     * @param tutorialString name of the tutorial class to be checked
+     * @param tutorialClass name of the tutorial class to be checked
      * @return true if the class name is in the list. False otherwise.
      */
-    public boolean hasTutorialClass(TutorialClass tutorialString) {
-        for (TutorialClass tutorialClass : tutorialClasses) {
-            if (tutorialString.equals(tutorialClass)) {
+    public boolean hasTutorialClass(TutorialClass tutorialClass) {
+        for (TutorialClass tutorialClassInModule : tutorialClasses) {
+            if (tutorialClass.equals(tutorialClassInModule)) {
                 return true;
             }
         }
@@ -135,9 +135,9 @@ public class ModuleCode {
      */
     public String listTutorialClasses() {
         if (tutorialClasses.size() == 0) {
-            return String.format("Tutorials in %s: None!", value);
+            return String.format("Tutorials in %s: None!", moduleCode);
         } else {
-            StringBuilder tutorialsString = new StringBuilder(String.format("Tutorials in %s:", value));
+            StringBuilder tutorialsString = new StringBuilder(String.format("Tutorials in %s:", moduleCode));
             for (TutorialClass tutorialClass : tutorialClasses) {
                 tutorialsString.append(" ");
                 tutorialsString.append(tutorialClass.toString());
@@ -149,19 +149,19 @@ public class ModuleCode {
     /**
      * Adds an empty tutorial with the given name into the module.
      *
-     * @param tutorialString name of tutorial class to be added.
+     * @param tutorialClass name of tutorial class to be added.
      */
-    public void addTutorialClass(TutorialClass tutorialString) {
-        tutorialClasses.add(tutorialString);
+    public void addTutorialClass(TutorialClass tutorialClass) {
+        tutorialClasses.add(tutorialClass);
     }
 
     /**
      * Deletes a tutorial with the given name from the module.
      * The tutorial has to exist to be used in this function.
      *
-     * @param tutorialString name of tutorial class to be deleted.
+     * @param tutorialClass name of tutorial class to be deleted.
      */
-    public void deleteTutorialClass(TutorialClass tutorialString) {
-        tutorialClasses.remove(tutorialString);
+    public void deleteTutorialClass(TutorialClass tutorialClass) {
+        tutorialClasses.remove(tutorialClass);
     }
 }

--- a/src/main/java/seedu/address/model/module/ModuleCode.java
+++ b/src/main/java/seedu/address/model/module/ModuleCode.java
@@ -1,5 +1,8 @@
 package seedu.address.model.module;
 
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+
 import static seedu.address.commons.util.AppUtil.checkArgument;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
@@ -121,11 +124,39 @@ public class ModuleCode {
     }
 
     /**
+     * List all the tutorial classes under this module.
+     *
+     * @return String of tutorial classes under this module.
+     */
+    public String listTutorialClasses() {
+        if (tutorialClasses.size() == 0) {
+            return String.format("Tutorials in %s: None!", value);
+        } else {
+            StringBuilder tutorialsString = new StringBuilder(String.format("Tutorials in %s: ", value));
+            for (TutorialClass tutorialClass : tutorialClasses) {
+                tutorialsString.append(" ");
+                tutorialsString.append(tutorialClass.toString());
+            }
+            return tutorialsString.toString().trim();
+        }
+    }
+
+    /**
      * Adds an empty tutorial with the given name into the module.
      *
      * @param tutorialString name of tutorial class to be added.
      */
     public void addTutorialClass(TutorialClass tutorialString) {
         tutorialClasses.add(tutorialString);
+    }
+
+    /**
+     * Deletes a tutorial with the given name from the module.
+     * The tutorial has to exist to be used in this function.
+     *
+     * @param tutorialString name of tutorial class to be deleted.
+     */
+    public void deleteTutorialClass(TutorialClass tutorialString) {
+        tutorialClasses.remove(tutorialString);
     }
 }

--- a/src/main/java/seedu/address/model/module/ModuleCode.java
+++ b/src/main/java/seedu/address/model/module/ModuleCode.java
@@ -1,8 +1,5 @@
 package seedu.address.model.module;
 
-import seedu.address.logic.commands.Command;
-import seedu.address.logic.commands.CommandResult;
-
 import static seedu.address.commons.util.AppUtil.checkArgument;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 

--- a/src/main/java/seedu/address/model/module/ModuleCode.java
+++ b/src/main/java/seedu/address/model/module/ModuleCode.java
@@ -129,7 +129,7 @@ public class ModuleCode {
         if (tutorialClasses.size() == 0) {
             return String.format("Tutorials in %s: None!", value);
         } else {
-            StringBuilder tutorialsString = new StringBuilder(String.format("Tutorials in %s: ", value));
+            StringBuilder tutorialsString = new StringBuilder(String.format("Tutorials in %s:", value));
             for (TutorialClass tutorialClass : tutorialClasses) {
                 tutorialsString.append(" ");
                 tutorialsString.append(tutorialClass.toString());

--- a/src/main/java/seedu/address/model/module/ModuleContainsKeywordPredicate.java
+++ b/src/main/java/seedu/address/model/module/ModuleContainsKeywordPredicate.java
@@ -18,7 +18,7 @@ public class ModuleContainsKeywordPredicate implements Predicate<ModuleCode> {
 
     @Override
     public boolean test(ModuleCode moduleCode) {
-        return StringUtil.containsPartialWordIgnoreCase(moduleCode.getModule().value, keyword);
+        return StringUtil.containsPartialWordIgnoreCase(moduleCode.getModule().moduleCode, keyword);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/module/TutorialClass.java
+++ b/src/main/java/seedu/address/model/module/TutorialClass.java
@@ -22,7 +22,7 @@ public class TutorialClass {
      */
     public static final String VALIDATION_REGEX = "^[A-Z]\\d{2}$";
 
-    public final String value;
+    public final String tutorialName;
     private final ArrayList<Person> students;
 
     /**
@@ -33,7 +33,7 @@ public class TutorialClass {
     public TutorialClass(String tutorialClass) {
         requireAllNonNull(tutorialClass);
         checkArgument(isValidTutorialClass(tutorialClass), MESSAGE_CONSTRAINTS);
-        this.value = tutorialClass;
+        this.tutorialName = tutorialClass;
         this.students = new ArrayList<>();
     }
 
@@ -46,7 +46,7 @@ public class TutorialClass {
     public TutorialClass(String tutorialClass, ArrayList<Person> students) {
         requireAllNonNull(tutorialClass);
         checkArgument(isValidTutorialClass(tutorialClass), MESSAGE_CONSTRAINTS);
-        this.value = tutorialClass;
+        this.tutorialName = tutorialClass;
         this.students = students;
     }
 
@@ -65,7 +65,7 @@ public class TutorialClass {
 
     @Override
     public String toString() {
-        return value;
+        return tutorialName;
     }
 
     @Override
@@ -80,11 +80,11 @@ public class TutorialClass {
         }
 
         TutorialClass otherTutorialClass = (TutorialClass) other;
-        return value.equals(otherTutorialClass.value);
+        return tutorialName.equals(otherTutorialClass.tutorialName);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return tutorialName.hashCode();
     }
 }

--- a/src/main/java/seedu/address/model/module/TutorialContainsKeywordPredicate.java
+++ b/src/main/java/seedu/address/model/module/TutorialContainsKeywordPredicate.java
@@ -18,7 +18,7 @@ public class TutorialContainsKeywordPredicate implements Predicate<TutorialClass
 
     @Override
     public boolean test(TutorialClass tutorialClass) {
-        return StringUtil.containsPartialWordIgnoreCase(tutorialClass.getTutorialClass().value, keyword);
+        return StringUtil.containsPartialWordIgnoreCase(tutorialClass.getTutorialClass().tutorialName, keyword);
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/AddClassCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddClassCommandTest.java
@@ -3,7 +3,7 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.AddClassCommand.MESSAGE_ADD_REMARK_SUCCESS;
+import static seedu.address.logic.commands.AddClassCommand.MESSAGE_ADD_CLASS_SUCCESS;
 import static seedu.address.logic.commands.AddClassCommand.MESSAGE_DUPLICATE_CLASS;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_BOB;
@@ -34,7 +34,7 @@ public class AddClassCommandTest {
 
         assertCommandSuccess(new AddClassCommand(new ModuleCode(VALID_MODULE_AMY),
                 new TutorialClass(VALID_TUTORIAL_AMY)), model,
-            String.format(MESSAGE_ADD_REMARK_SUCCESS, VALID_MODULE_AMY, VALID_TUTORIAL_AMY), model);
+            String.format(MESSAGE_ADD_CLASS_SUCCESS, VALID_MODULE_AMY, VALID_TUTORIAL_AMY), model);
     }
 
     @Test
@@ -64,7 +64,7 @@ public class AddClassCommandTest {
 
         assertCommandSuccess(new AddClassCommand(new ModuleCode(VALID_MODULE_AMY),
                 new TutorialClass(VALID_TUTORIAL_BOB)), actualModel,
-            String.format(MESSAGE_ADD_REMARK_SUCCESS, VALID_MODULE_AMY, VALID_TUTORIAL_BOB), expectedModel);
+            String.format(MESSAGE_ADD_CLASS_SUCCESS, VALID_MODULE_AMY, VALID_TUTORIAL_BOB), expectedModel);
 
         ModuleCode moduleFromList = actualModel.findModuleFromList(module);
         assertEquals(moduleFromList.getTutorialClasses().get(1).toString(), VALID_TUTORIAL_BOB);

--- a/src/test/java/seedu/address/logic/commands/DeleteClassCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteClassCommandTest.java
@@ -1,0 +1,4 @@
+package seedu.address.logic.commands;
+
+public class DeleteClassCommandTest {
+}

--- a/src/test/java/seedu/address/logic/commands/DeleteClassCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteClassCommandTest.java
@@ -1,4 +1,13 @@
 package seedu.address.logic.commands;
 
+import org.junit.jupiter.api.Test;
+
 public class DeleteClassCommandTest {
+    @Test
+    void execute() {
+    }
+
+    @Test
+    void testEquals() {
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteClassCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteClassCommandTest.java
@@ -1,13 +1,97 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TUTORIAL_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TUTORIAL_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.DeleteClassCommand.MESSAGE_CLASS_NOT_FOUND;
+import static seedu.address.logic.commands.DeleteClassCommand.MESSAGE_DELETE_CLASS_SUCCESS;
+import static seedu.address.logic.commands.DeleteClassCommand.MESSAGE_MODULE_NOT_FOUND;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.module.ModuleCode;
+import seedu.address.model.module.TutorialClass;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for AddClassCommand.
+ */
 public class DeleteClassCommandTest {
+    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
     @Test
-    void execute() {
+    public void execute_success() {
+        Model actualModel = new ModelManager();
+        Model expectedModel = new ModelManager();
+        ModuleCode module = new ModuleCode(VALID_MODULE_AMY, VALID_TUTORIAL_AMY);
+        actualModel.addModule(module);
+        expectedModel.addModule(new ModuleCode(VALID_MODULE_AMY));
+
+        assertCommandSuccess(new DeleteClassCommand(new ModuleCode(VALID_MODULE_AMY),
+                        new TutorialClass(VALID_TUTORIAL_AMY)), actualModel,
+                String.format(MESSAGE_DELETE_CLASS_SUCCESS, VALID_MODULE_AMY, VALID_TUTORIAL_AMY), expectedModel);
+
+        ModuleCode moduleFromList = actualModel.findModuleFromList(module);
+        assertEquals(moduleFromList.getTutorialClasses().size(), 0);
     }
 
     @Test
-    void testEquals() {
+    public void execute_moduleNotFound_fail() {
+        ModuleCode module = new ModuleCode(VALID_MODULE_AMY, VALID_TUTORIAL_AMY);
+        model.addModule(module);
+
+        assertCommandFailure(new DeleteClassCommand(new ModuleCode(VALID_MODULE_BOB),
+                        new TutorialClass(VALID_TUTORIAL_AMY)), model,
+                String.format(MESSAGE_MODULE_NOT_FOUND, VALID_MODULE_BOB));
+    }
+
+    @Test
+    public void execute_tutorialNotFound_fail() {
+        ModuleCode module = new ModuleCode(VALID_MODULE_AMY, VALID_TUTORIAL_AMY);
+        model.addModule(module);
+
+        String errorMessage = String.format(MESSAGE_CLASS_NOT_FOUND, VALID_MODULE_AMY, VALID_TUTORIAL_BOB);
+        String listOfTutorials = module.listTutorialClasses();
+        String expectedMessage = errorMessage + "\n" + listOfTutorials;
+        assertCommandFailure(new DeleteClassCommand(new ModuleCode(VALID_MODULE_AMY),
+                        new TutorialClass(VALID_TUTORIAL_BOB)), model, expectedMessage);
+    }
+
+    @Test
+    public void equals() {
+        final DeleteClassCommand standardCommand = new DeleteClassCommand(new ModuleCode(VALID_MODULE_AMY),
+                new TutorialClass(VALID_TUTORIAL_AMY));
+
+        // same values -> returns true
+        DeleteClassCommand commandWithSameValues = new DeleteClassCommand(new ModuleCode(VALID_MODULE_AMY),
+                new TutorialClass(VALID_TUTORIAL_AMY));
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+
+        // different module code -> returns false
+        assertFalse(standardCommand.equals(new DeleteClassCommand(new ModuleCode(VALID_MODULE_BOB),
+                new TutorialClass(VALID_TUTORIAL_AMY))));
+
+        // different tutorial class -> returns true
+        assertTrue(standardCommand.equals(new DeleteClassCommand(new ModuleCode(VALID_MODULE_AMY),
+                new TutorialClass(VALID_TUTORIAL_BOB))));
     }
 }
+

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.logic.commands.AddClassCommand;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.DeleteClassCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
@@ -114,6 +115,17 @@ public class AddressBookParserTest {
         assertEquals(new AddClassCommand(new ModuleCode(moduleCode),
                 new TutorialClass(tutorialClass)), command);
     }
+
+    @Test
+    public void parseCommand_deleteClass() throws Exception {
+        final String moduleCode = "CS2103T";
+        final String tutorialClass = "T09";
+        AddClassCommand command = (AddClassCommand) parser.parseCommand(AddClassCommand.COMMAND_WORD + " "
+                + PREFIX_MODULECODE + moduleCode + " " + PREFIX_TUTORIALCLASS + tutorialClass);
+        assertEquals(new DeleteClassCommand(new ModuleCode(moduleCode),
+                new TutorialClass(tutorialClass)), command);
+    }
+
     @Test
     public void parseCommand_listClasses() throws Exception {
         assertTrue(parser.parseCommand(ListClassesCommand.COMMAND_WORD) instanceof ListClassesCommand);

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -120,7 +120,8 @@ public class AddressBookParserTest {
     public void parseCommand_deleteClass() throws Exception {
         final String moduleCode = "CS2103T";
         final String tutorialClass = "T09";
-        AddClassCommand command = (AddClassCommand) parser.parseCommand(AddClassCommand.COMMAND_WORD + " "
+        DeleteClassCommand command = (DeleteClassCommand)
+                parser.parseCommand(DeleteClassCommand.COMMAND_WORD + " "
                 + PREFIX_MODULECODE + moduleCode + " " + PREFIX_TUTORIALCLASS + tutorialClass);
         assertEquals(new DeleteClassCommand(new ModuleCode(moduleCode),
                 new TutorialClass(tutorialClass)), command);

--- a/src/test/java/seedu/address/logic/parser/DeleteClassCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteClassCommandParserTest.java
@@ -1,4 +1,9 @@
 package seedu.address.logic.parser;
 
+import org.junit.jupiter.api.Test;
+
 public class DeleteClassCommandParserTest {
+    @Test
+    void parse() {
+    }
 }

--- a/src/test/java/seedu/address/logic/parser/DeleteClassCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteClassCommandParserTest.java
@@ -1,0 +1,4 @@
+package seedu.address.logic.parser;
+
+public class DeleteClassCommandParserTest {
+}

--- a/src/test/java/seedu/address/logic/parser/DeleteClassCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteClassCommandParserTest.java
@@ -1,9 +1,52 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.commands.CommandTestUtil.MODULE_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.TUTORIAL_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TUTORIAL_AMY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULECODE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIALCLASS;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.DeleteClassCommand;
+import seedu.address.model.module.ModuleCode;
+import seedu.address.model.module.TutorialClass;
+
 public class DeleteClassCommandParserTest {
+    private final DeleteClassCommandParser parser = new DeleteClassCommandParser();
+
+
     @Test
-    void parse() {
+    public void parse_tutorialTest() {
+        // have tutorial class
+        String expectedMessage = TutorialClass.MESSAGE_CONSTRAINTS;
+
+        String userInput = MODULE_DESC_AMY + TUTORIAL_DESC_AMY;
+        DeleteClassCommand expectedCommand = new DeleteClassCommand(new ModuleCode(VALID_MODULE_AMY),
+                new TutorialClass(VALID_TUTORIAL_AMY));
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // no tutorial class
+        userInput = MODULE_DESC_AMY + " " + PREFIX_TUTORIALCLASS;
+        assertParseFailure(parser, userInput, expectedMessage);
+    }
+
+    @Test
+    public void parse_missingCompulsoryField_failure() {
+        String expectedMessage1 = String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
+                DeleteClassCommand.MESSAGE_USAGE);
+        String expectedMessage2 = ModuleCode.MESSAGE_CONSTRAINTS;
+
+        // no parameters
+        assertParseFailure(parser, " ", expectedMessage1);
+
+        // no module stated
+        assertParseFailure(parser, " " + PREFIX_MODULECODE + ""
+                + TUTORIAL_DESC_AMY, expectedMessage2);
     }
 }
+

--- a/src/test/java/seedu/address/model/module/ModuleCodeTest.java
+++ b/src/test/java/seedu/address/model/module/ModuleCodeTest.java
@@ -25,7 +25,7 @@ public class ModuleCodeTest {
         assertTrue(module.equals(module));
 
         // same values -> returns true
-        ModuleCode remarkCopy = new ModuleCode(module.value);
+        ModuleCode remarkCopy = new ModuleCode(module.moduleCode);
         assertTrue(module.equals(remarkCopy));
 
         // different types -> returns false

--- a/src/test/java/seedu/address/model/module/ModuleCodeTest.java
+++ b/src/test/java/seedu/address/model/module/ModuleCodeTest.java
@@ -11,6 +11,12 @@ public class ModuleCodeTest {
 
     public static final String VALID_MODULE_CODE = "CS2103T";
     public static final String INVALID_MODULE_CODE = "CS210T";
+    public static final String VALID_TUTORIAL_1 = "T01";
+    public static final String VALID_TUTORIAL_2 = "T02";
+
+    /**
+     * Test cases to check the equality of two ModuleCode objects
+     */
     @Test
     public void equals() {
         ModuleCode module = new ModuleCode("CS2103T");
@@ -32,20 +38,51 @@ public class ModuleCodeTest {
         ModuleCode differentModule = new ModuleCode("CS1101S");
         assertFalse(module.equals(differentModule));
     }
+
+    /**
+     * Tests isValidModuleCode with a valid module code.
+     */
     @Test
-    void isValidTutorialClass_success() {
+    void isValidModuleCode_success() {
         assertTrue(isValidModuleCode(VALID_MODULE_CODE));
     }
 
+    /**
+     * Tests isValidModuleCode with an invalid module code
+     */
     @Test
-    void isValidTutorialClass_failure() {
+    void isValidModuleCode_failure() {
         assertFalse(isValidModuleCode(INVALID_MODULE_CODE));
     }
 
+    /**
+     * Checks if the string output is as expected for a valid module.
+     */
     @Test
     void testToString_success() {
         ModuleCode moduleCode = new ModuleCode(VALID_MODULE_CODE);
         assertEquals(moduleCode.toString(), VALID_MODULE_CODE);
     }
 
+    /**
+     * Checks if the string output is as expected for a set list of tutorial classes.
+     */
+    @Test
+    void listTutorialClasses_success() {
+        ModuleCode moduleCode = new ModuleCode(VALID_MODULE_CODE);
+        moduleCode.addTutorialClass(new TutorialClass(VALID_TUTORIAL_1));
+        moduleCode.addTutorialClass(new TutorialClass(VALID_TUTORIAL_2));
+        String expectedString = "Tutorials in CS2103T: T01 T02";
+        assertEquals(moduleCode.listTutorialClasses(), expectedString);
+    }
+
+    /**
+     * Checks if the string output is as expected for an empty module.
+     */
+    @Test
+    void listTutorialClasses_empty_success() {
+        ModuleCode moduleCode = new ModuleCode(VALID_MODULE_CODE);
+        String expectedString = "Tutorials in CS2103T: None!";
+        assertEquals(moduleCode.listTutorialClasses(), expectedString);
+    }
 }

--- a/src/test/java/seedu/address/model/module/TutorialClassTest.java
+++ b/src/test/java/seedu/address/model/module/TutorialClassTest.java
@@ -26,7 +26,7 @@ public class TutorialClassTest {
         assertTrue(tutorialClass.equals(tutorialClass));
 
         // same values -> returns true
-        TutorialClass remarkCopy = new TutorialClass(tutorialClass.value);
+        TutorialClass remarkCopy = new TutorialClass(tutorialClass.tutorialName);
         assertTrue(tutorialClass.equals(remarkCopy));
 
         // different types -> returns false
@@ -54,13 +54,13 @@ public class TutorialClassTest {
     void isSameTutorialClass() {
         ModuleCode module = new ModuleBuilder().withModuleCode("CS2102").withTutorialClasses(VALID_TUTORIAL).build();
         TutorialClass tutorialClass = module.getTutorialClasses().get(1);
-        String tutorialClassString = tutorialClass.value;
+        String tutorialClassString = tutorialClass.tutorialName;
         assertTrue(VALID_TUTORIAL.equals(tutorialClassString));
 
         // different module but same tutorial class notation
         module = new ModuleBuilder().withModuleCode("CS2105").withTutorialClasses(VALID_TUTORIAL).build();
         tutorialClass = module.getTutorialClasses().get(1);
-        tutorialClassString = tutorialClass.value;
+        tutorialClassString = tutorialClass.tutorialName;
         assertTrue(VALID_TUTORIAL.equals(tutorialClassString));
     }
 
@@ -69,13 +69,13 @@ public class TutorialClassTest {
         // same module but different tutorial class
         ModuleCode module = new ModuleBuilder().withModuleCode("CS2102").withTutorialClasses(VALID_TUTORIAL).build();
         TutorialClass tutorialClass = module.getTutorialClasses().get(0);
-        String tutorialClassString = tutorialClass.value;
+        String tutorialClassString = tutorialClass.tutorialName;
         assertFalse(VALID_TUTORIAL.equals(tutorialClassString));
 
         // different module and different tutorial class
         module = new ModuleBuilder().withModuleCode("CS2109").withTutorialClasses("T05").build();
         tutorialClass = module.getTutorialClasses().get(1);
-        String tutorialClassToCompare = tutorialClass.value;
+        String tutorialClassToCompare = tutorialClass.tutorialName;
         assertFalse(tutorialClassString.equals(tutorialClassToCompare));
     }
 

--- a/src/test/java/seedu/address/testutil/ModuleBuilder.java
+++ b/src/test/java/seedu/address/testutil/ModuleBuilder.java
@@ -51,6 +51,6 @@ public class ModuleBuilder {
     }
 
     public ModuleCode build() {
-        return new ModuleCode(moduleCode.value, tutorialClasses);
+        return new ModuleCode(moduleCode.toString(), tutorialClasses);
     }
 }


### PR DESCRIPTION
Fixes #5.

Adds the functionality to delete the module code: tutorial class specified from the model. If module code does not exist, it returns an error. If tutorial does not exist within the module, it brings up the list of tutorial classes that can be deleted from that module.

TODO:
- [x] add more test cases
- bring up list of modules when non-existent module code is entered (Need to do?)