### PR TITLE
Update to check email needs to be unique in the list of students

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,9 @@ dependencies {
     implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'win'
     implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'mac'
     implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'linux'
+    implementation group: 'org.openjfx', name: 'javafx-swing', version: javaFxVersion, classifier: 'win'
+    implementation group: 'org.openjfx', name: 'javafx-swing', version: javaFxVersion, classifier: 'mac'
+    implementation group: 'org.openjfx', name: 'javafx-swing', version: javaFxVersion, classifier: 'linux'
 
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.7.0'
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.7.4'

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -52,7 +52,7 @@ public class Person {
     }
 
     /**
-     * Returns true if both persons have the same StudentId.
+     * Returns true if both persons have the same StudentId or email.
      * This defines a weaker notion of equality between two persons.
      */
     public boolean isSamePerson(Person otherPerson) {
@@ -60,8 +60,14 @@ public class Person {
             return true;
         }
 
-        return otherPerson != null
-                && otherPerson.getStudentId().equals(getStudentId());
+        if (otherPerson == null) {
+            return false;
+        }
+
+        boolean checkSameStudentId = otherPerson.getStudentId().equals(getStudentId());
+        boolean checkSameEmail = otherPerson.getEmail().equals(getEmail());
+
+        return otherPerson != null && (checkSameStudentId || checkSameEmail);
     }
 
     /**

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -30,10 +30,6 @@
       <FlowPane fx:id="tags" />
       <Label fx:id="stuId" styleClass="cell_small_label" text="\$stuId" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
-      <HBox spacing="5" alignment="CENTER_LEFT">
-        <Label fx:id="module" styleClass="cell_small_label" text="\$module" />
-        <Label fx:id="tutorial" styleClass="cell_small_label" text="\$tutorial" />
-      </HBox>
     </VBox>
   </GridPane>
 </HBox>

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -40,19 +40,24 @@ public class PersonTest {
                 .withStudentId(VALID_STUDENT_ID_BOB).withTags(VALID_TAG_FRIEND).build();
         assertFalse(ALICE.isSamePerson(editedAlice));
 
-        // same email, all other attributes different --> return false
+        // same email, all other attributes different --> return true
         editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB)
                 .withStudentId(VALID_STUDENT_ID_BOB).withTags(VALID_TAG_FRIEND).build();
-        assertFalse(ALICE.isSamePerson(editedAlice));
+
+        assertTrue(ALICE.isSamePerson(editedAlice));
 
         // same studentId, all other attributes different -> returns true
         editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).withEmail(VALID_EMAIL_BOB)
                 .withTags(VALID_TAG_FRIEND).build();
         assertTrue(ALICE.isSamePerson(editedAlice));
 
-        // different studentId, all other attributes same -> returns false
+        // different studentId, all other attributes same -> returns true
         editedAlice = new PersonBuilder(ALICE).withStudentId(VALID_STUDENT_ID_BOB).build();
-        assertFalse(ALICE.isSamePerson(editedAlice));
+        assertTrue(ALICE.isSamePerson(editedAlice));
+
+        // different name, all other attributes same --> return true
+        editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).build();
+        assertTrue(ALICE.isSamePerson(editedAlice));
     }
 
     @Test


### PR DESCRIPTION
Update isSamePerson definition to include email value check

* Email is now a unique field that would "determine" if a Person
is the same person.

* Ensures that if user specifies the same email as an existing student
in the list, the system will throw a duplicate error.
