### PR TITLE
Added functionality to delete team

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteClassCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteClassCommand.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULECODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIALCLASS;
 
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.messages.ModuleMessages;
 import seedu.address.model.Model;
 import seedu.address.model.module.ModuleCode;
 import seedu.address.model.module.TutorialClass;
@@ -32,7 +33,8 @@ public class DeleteClassCommand extends Command {
     /**
      * Constructs a DeleteClassCommand to delete the specified {@code TutorialClass}
      * from the specified {@code ModuleCode}.
-     * @param module The module code of the tutorial class to be deleted.
+     * 
+     * @param module        The module code of the tutorial class to be deleted.
      * @param tutorialClass The tutorial class to be deleted.
      */
     public DeleteClassCommand(ModuleCode module, TutorialClass tutorialClass) {
@@ -47,12 +49,13 @@ public class DeleteClassCommand extends Command {
 
         ModuleCode existingModule = model.findModuleFromList(module);
         if (existingModule == null) {
-            String moduleNotFoundMessage = String.format(MESSAGE_MODULE_NOT_FOUND, module);
+            String moduleNotFoundMessage = String.format(ModuleMessages.MESSAGE_MODULE_NOT_FOUND, module);
             throw new CommandException(moduleNotFoundMessage);
         }
 
         if (!(existingModule.hasTutorialClass(tutorialString))) {
-            String classNotFoundMessage = String.format(MESSAGE_CLASS_NOT_FOUND, module, tutorialString);
+            String classNotFoundMessage = String.format(ModuleMessages.MESSAGE_TUTORIAL_DOES_NOT_BELONG_TO_MODULE,
+                    tutorialString, module);
             String tutorialList = existingModule.listTutorialClasses();
             throw new CommandException(classNotFoundMessage + "\n" + tutorialList);
         } else {
@@ -63,8 +66,10 @@ public class DeleteClassCommand extends Command {
     }
 
     /**
-     * Generates a command execution success message based on whether the tutorial class is successfully deleted.
-     * @param module The module code of the tutorial class.
+     * Generates a command execution success message based on whether the tutorial
+     * class is successfully deleted.
+     * 
+     * @param module         The module code of the tutorial class.
      * @param tutorialString The tutorial class.
      * @return The success message.
      */

--- a/src/main/java/seedu/address/logic/commands/DeleteTeamCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTeamCommand.java
@@ -1,0 +1,117 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULECODE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIALCLASS;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.messages.ModuleMessages;
+import seedu.address.model.Model;
+import seedu.address.model.module.ModuleCode;
+import seedu.address.model.module.ModuleTutorialPair;
+import seedu.address.model.module.TutorialClass;
+import seedu.address.model.module.TutorialTeam;
+
+/**
+ * A class used to handle the deletion of tutorial team.
+ */
+public class DeleteTeamCommand extends Command {
+    public static final String MESSAGE_DELETE_TEAM_SUCCESS = "Removed %1$s from %2$s %3$s!";
+    public static final String MESSAGE_TEAM_NOT_FOUND = "%1$s not in %2$s %3$s!";
+    public static final String COMMAND_WORD = "/delete_team";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Deletes a team from the tutorial class specified\n"
+            + "Parameters:" + PREFIX_MODULECODE + "MODULE_CODE "
+            + PREFIX_TUTORIALCLASS + "TUTORIAL_CLASS " + PREFIX_NAME + "TEAM_NAME\n"
+            + "Example: " + COMMAND_WORD + " " + PREFIX_MODULECODE + " CS2103T "
+            + PREFIX_TUTORIALCLASS + "T09 " + PREFIX_NAME + "Team 1";
+
+    private final ModuleCode module;
+    private final TutorialClass tutorialClass;
+    private final TutorialTeam team;
+
+    /**
+     * Constructs a DeleteTeamCommand to delete the specified {@code TutorialTeam}
+     * from the specified {@code ModuleCode} and {@code TutorialClass}.
+     * 
+     * @param module        The module code of the tutorial class to be deleted.
+     * @param tutorialClass The tutorial class to be deleted.
+     * @param teamName      The name of the team to be deleted.
+     */
+    public DeleteTeamCommand(ModuleCode module, TutorialClass tutorialClass, String teamName) {
+        requireAllNonNull(module, tutorialClass, teamName);
+        this.module = module;
+        this.tutorialClass = tutorialClass;
+        this.team = new TutorialTeam(teamName);
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        ModuleTutorialPair moduleAndTutorialClass = getModuleAndTutorialClass(model);
+        ModuleCode module = moduleAndTutorialClass.getModule();
+        TutorialClass tutorialClass = moduleAndTutorialClass.getTutorialClass();
+        if (tutorialClass.hasTeam(team)) {
+            tutorialClass.deleteTeam(team);
+        } else {
+            throw new CommandException(String.format(MESSAGE_TEAM_NOT_FOUND, team, module, tutorialClass));
+        }
+
+        return new CommandResult(generateSuccessMessage(module, tutorialClass, team));
+    }
+
+    protected ModuleTutorialPair getModuleAndTutorialClass(Model model) throws CommandException {
+        requireNonNull(model);
+        ModuleCode module = getModule();
+        TutorialClass tutorialClass = getTutorialClass();
+        ModuleCode existingModule = model.findModuleFromList(module);
+        TutorialClass existingTutorialClass = model.findTutorialClassFromList(tutorialClass, existingModule);
+        if (existingModule == null) {
+            throw new CommandException(String.format(ModuleMessages.MESSAGE_MODULE_NOT_FOUND, module));
+        }
+        if (existingTutorialClass == null) {
+            throw new CommandException(
+                    String.format(ModuleMessages.MESSAGE_TUTORIAL_DOES_NOT_BELONG_TO_MODULE, tutorialClass, module));
+        }
+        return new ModuleTutorialPair(existingModule, existingTutorialClass);
+    }
+
+    protected ModuleCode getModule() {
+        return module;
+    }
+
+    protected TutorialClass getTutorialClass() {
+        return tutorialClass;
+    }
+
+    /**
+     * Generates a command execution success message based on whether the tutorial
+     * class is successfully deleted.
+     * 
+     * @param module         The module code of the tutorial class.
+     * @param tutorialString The tutorial class.
+     * @return The success message.
+     */
+    private String generateSuccessMessage(ModuleCode module, TutorialClass tutorialString, TutorialTeam team) {
+        return String.format(MESSAGE_DELETE_TEAM_SUCCESS, team, module, tutorialString);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof DeleteTeamCommand)) {
+            return false;
+        }
+
+        DeleteTeamCommand e = (DeleteTeamCommand) other;
+        return module.equals(e.module) && tutorialClass.equals(e.tutorialClass) && team.equals(e.team);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddTeamCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddTeamCommandParser.java
@@ -23,6 +23,7 @@ public class AddTeamCommandParser implements Parser<AddTeamCommand> {
      * Parses the given {@code String} of arguments in the context of the
      * {@code AddClassCommandParser}
      * and returns a {@code AddClassCommandParser} object for execution.
+     * 
      * @throws ParseException if the user input does not conform the expected format
      */
     public AddTeamCommand parse(String args) throws ParseException {
@@ -36,27 +37,27 @@ public class AddTeamCommandParser implements Parser<AddTeamCommand> {
         }
 
         boolean isTeamSizePresent = argMultimap.getValue(PREFIX_TEAM_SIZE).isPresent();
-        String moduleCode = argMultimap.getValue(PREFIX_MODULECODE).orElse("");
-        String tutorialClass = argMultimap.getValue(PREFIX_TUTORIALCLASS).orElse("");
+        ModuleCode moduleCode = ParserUtil.parseModuleCode(argMultimap.getValue(PREFIX_MODULECODE).get());
+        TutorialClass tutorialClass = ParserUtil.parseTutorialClass(argMultimap.getValue(PREFIX_TUTORIALCLASS).get());
         String teamName = argMultimap.getValue(PREFIX_NAME).orElse("");
-        if (!(ModuleCode.isValidModuleCode(moduleCode))) {
-            throw new ParseException(ModuleCode.MESSAGE_CONSTRAINTS);
-        }
-        if (!(TutorialClass.isValidTutorialClass(tutorialClass))) {
-            throw new ParseException(TutorialClass.MESSAGE_CONSTRAINTS);
-        }
 
         if (!TutorialTeam.isValidTeamName(teamName)) {
             throw new ParseException(TutorialTeam.MESSAGE_NAME_CONSTRAINTS);
         }
+
         if (isTeamSizePresent) {
-            int teamSize = Integer.parseInt(argMultimap.getValue(PREFIX_TEAM_SIZE).get());
+            int teamSize;
+            try {
+                teamSize = Integer.parseInt(argMultimap.getValue(PREFIX_TEAM_SIZE).get());
+            } catch (NumberFormatException e) {
+                throw new ParseException(TutorialTeam.MESSAGE_SIZE_CONSTRAINTS);
+            }
             if (teamSize <= 0) {
                 throw new ParseException(TutorialTeam.MESSAGE_SIZE_CONSTRAINTS);
             }
-            return new AddTeamCommand(new ModuleCode(moduleCode), new TutorialClass(tutorialClass), teamName, teamSize);
+            return new AddTeamCommand(moduleCode, tutorialClass, teamName, teamSize);
         } else {
-            return new AddTeamCommand(new ModuleCode(moduleCode), new TutorialClass(tutorialClass), teamName);
+            return new AddTeamCommand(moduleCode, tutorialClass, teamName);
         }
     }
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -15,6 +15,7 @@ import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteClassCommand;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeleteTeamCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.HelpCommand;
@@ -101,6 +102,9 @@ public class AddressBookParser {
 
         case AddTeamCommand.COMMAND_WORD:
             return new AddTeamCommandParser().parse(arguments);
+
+        case DeleteTeamCommand.COMMAND_WORD:
+            return new DeleteTeamCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/DeleteTeamCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteTeamCommandParser.java
@@ -3,11 +3,12 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULECODE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIALCLASS;
 
 import java.util.stream.Stream;
 
-import seedu.address.logic.commands.DeleteClassCommand;
+import seedu.address.logic.commands.DeleteTeamCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.module.ModuleCode;
 import seedu.address.model.module.TutorialClass;
@@ -16,7 +17,7 @@ import seedu.address.model.module.TutorialClass;
  * Parses input arguments and creates a new {@code DeleteClassCommandParser}
  * object
  */
-public class DeleteClassCommandParser implements Parser<DeleteClassCommand> {
+public class DeleteTeamCommandParser implements Parser<DeleteTeamCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the
      * {@code DeleteClassCommandParser}
@@ -24,18 +25,19 @@ public class DeleteClassCommandParser implements Parser<DeleteClassCommand> {
      * 
      * @throws ParseException if the user input does not conform the expected format
      */
-    public DeleteClassCommand parse(String args) throws ParseException {
+    public DeleteTeamCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_MODULECODE, PREFIX_TUTORIALCLASS);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_MODULECODE, PREFIX_TUTORIALCLASS,
+                PREFIX_NAME);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_MODULECODE, PREFIX_TUTORIALCLASS)
+        if (!arePrefixesPresent(argMultimap, PREFIX_MODULECODE, PREFIX_TUTORIALCLASS, PREFIX_NAME)
                 || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteClassCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteTeamCommand.MESSAGE_USAGE));
         }
-
         ModuleCode moduleCode = ParserUtil.parseModuleCode(argMultimap.getValue(PREFIX_MODULECODE).get());
         TutorialClass tutorialClass = ParserUtil.parseTutorialClass(argMultimap.getValue(PREFIX_TUTORIALCLASS).get());
-        return new DeleteClassCommand(moduleCode, tutorialClass);
+        String teamName = argMultimap.getValue(PREFIX_NAME).get();
+        return new DeleteTeamCommand(moduleCode, tutorialClass, teamName);
     }
 
     /**

--- a/src/main/java/seedu/address/model/module/TutorialClass.java
+++ b/src/main/java/seedu/address/model/module/TutorialClass.java
@@ -41,6 +41,7 @@ public class TutorialClass {
     /**
      * A constructor for TutorialClass. Creates an empty tutorial class with no
      * students.
+     * 
      * @param tutorialClass to be added
      */
     public TutorialClass(String tutorialClass) {
@@ -53,6 +54,7 @@ public class TutorialClass {
 
     /**
      * A constructor for TutorialClass. Creates a tutorial class with students.
+     * 
      * @param tutorialClass to be added
      * @param students      in the tutorial class
      */
@@ -67,6 +69,7 @@ public class TutorialClass {
     /**
      * A constructor for TutorialClass. Creates a tutorial class with students and
      * teams.
+     * 
      * @param tutorialClass to be added
      * @param students      in the tutorial class
      * @param teams         in the tutorial class
@@ -81,6 +84,7 @@ public class TutorialClass {
 
     /**
      * Set students to the tutorial class.
+     * 
      * @param students
      */
     public void setStudents(ArrayList<Person> students) {
@@ -96,6 +100,7 @@ public class TutorialClass {
 
     /**
      * Retrieves the tutorial class.
+     * 
      * @return The tutorial class.
      */
     public TutorialClass getTutorialClass() {
@@ -104,6 +109,7 @@ public class TutorialClass {
 
     /**
      * Retrieves the list of students in the tutorial class.
+     * 
      * @return The list of students in the tutorial class.
      */
     public ArrayList<Person> getStudents() {
@@ -112,6 +118,7 @@ public class TutorialClass {
 
     /**
      * Adds a student to the tutorial class.
+     * 
      * @param student
      */
     public void addStudent(Person student) {
@@ -120,6 +127,7 @@ public class TutorialClass {
 
     /**
      * Removes a student from the tutorial class if it exists.
+     * 
      * @param student
      * @return true if the student was removed
      */
@@ -129,6 +137,7 @@ public class TutorialClass {
 
     /**
      * Checks if the student is in the tutorial class.
+     * 
      * @param student
      * @return true if the student is in the tutorial class
      */
@@ -138,6 +147,7 @@ public class TutorialClass {
 
     /**
      * Retrieves the list of teams in the tutorial class.
+     * 
      * @return The list of teams in the tutorial class.
      */
     public ArrayList<TutorialTeam> getTeams() {
@@ -146,6 +156,7 @@ public class TutorialClass {
 
     /**
      * Adds a team to the tutorial class.
+     * 
      * @param team
      */
     public void addTeam(TutorialTeam team) {
@@ -154,10 +165,19 @@ public class TutorialClass {
 
     /**
      * Checks if the team is in the tutorial class.
+     * 
      * @param team
      */
     public boolean hasTeam(TutorialTeam team) {
         return teams.contains(team);
+    }
+
+    /**
+     * Deletes a team from the tutorial class.
+     * 
+     */
+    public void deleteTeam(TutorialTeam team) {
+        teams.remove(team);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/module/TutorialTeam.java
+++ b/src/main/java/seedu/address/model/module/TutorialTeam.java
@@ -38,8 +38,23 @@ public class TutorialTeam {
     }
 
     /**
+     * A constructor for TutorialTeam. Creates a tutorial team of unspecified size
+     * with no students.
+     * 
+     * @param tutorialTeam
+     */
+    public TutorialTeam(String tutorialTeam) {
+        requireAllNonNull(tutorialTeam);
+        checkArgument(isValidTeamName(tutorialTeam), MESSAGE_NAME_CONSTRAINTS);
+        this.teamName = tutorialTeam;
+        this.students = new ArrayList<>();
+        this.teamSize = Integer.MAX_VALUE;
+    }
+
+    /**
      * A constructor for TutorialTeam. Creates a tutorial team of a certain size
      * with no students.
+     * 
      * @param tutorialTeam
      * @param teamSize
      */
@@ -54,6 +69,7 @@ public class TutorialTeam {
 
     /**
      * A constructor for TutorialTeam. Creates a tutorial team with students.
+     * 
      * @param tutorialClass to be added
      * @param students      in the tutorial class
      */
@@ -68,6 +84,7 @@ public class TutorialTeam {
     /**
      * A constructor for TutorialTeam. Creates a tutorial team with students and
      * team size.
+     * 
      * @param tutorialClass to be added
      * @param students      in the tutorial class
      * @param teamSize      of the tutorial team
@@ -83,6 +100,7 @@ public class TutorialTeam {
 
     /**
      * Returns true if a given string is a valid tutorial team name.
+     * 
      * @param test
      */
     public static boolean isValidTeamName(String test) {
@@ -91,6 +109,7 @@ public class TutorialTeam {
 
     /**
      * Returns true if a given integer is a valid team size.
+     * 
      * @param test
      */
     public static boolean isValidSize(int test) {
@@ -99,6 +118,7 @@ public class TutorialTeam {
 
     /**
      * Set students to the tutorial team.
+     * 
      * @param students
      */
     public void setStudents(ArrayList<Person> students) {
@@ -107,6 +127,7 @@ public class TutorialTeam {
 
     /**
      * Retrieves the tutorial team.
+     * 
      * @return The tutorial team.
      */
     public TutorialTeam getTutorialTeam() {
@@ -115,6 +136,7 @@ public class TutorialTeam {
 
     /**
      * Retrieves the team name.
+     * 
      * @return The team name.
      */
     public String getTeamName() {
@@ -123,6 +145,7 @@ public class TutorialTeam {
 
     /**
      * Retrieves the team size.
+     * 
      * @return The team size.
      */
     public int getTeamSize() {
@@ -131,6 +154,7 @@ public class TutorialTeam {
 
     /**
      * Retrieves the list of students in the tutorial team.
+     * 
      * @return The list of students in the tutorial team.
      */
     public ArrayList<Person> getStudents() {
@@ -139,6 +163,7 @@ public class TutorialTeam {
 
     /**
      * Adds a student to the tutorial team.
+     * 
      * @param student
      */
     public void addStudent(Person student) {
@@ -147,6 +172,7 @@ public class TutorialTeam {
 
     /**
      * Removes a student from the tutorial class if it exists.
+     * 
      * @param student
      * @return true if the student was removed
      */
@@ -156,6 +182,7 @@ public class TutorialTeam {
 
     /**
      * Checks if the student is in the tutorial team.
+     * 
      * @param student
      * @return true if the student is in the tutorial class
      */


### PR DESCRIPTION
Fixes #100

This PR introduces the functionality to delete teams using the `/delete_team` command.

The following edge cases are handled:
- [ ] Module does not exist
- [ ] Tutorial class does not exist in module
- [ ] Team does not exist in tutorial class

The following bugs have been fixed:
- [ ] Creating a team with a non-integer team size will result in an error